### PR TITLE
Workspaces are specified absolutely from project cwd, create globs util

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -5,7 +5,7 @@ import parseJson from 'parse-json';
 import type { JSONValue, DependencySet } from './types';
 import * as fs from './utils/fs';
 import * as path from 'path';
-import multimatch from 'multimatch';
+import * as globs from './utils/globs';
 import { BoltError } from './utils/errors';
 
 async function getPackageStack(cwd: string) {
@@ -112,7 +112,7 @@ export default class Config {
           );
         });
 
-        let found = multimatch(filePaths, patterns);
+        let found = globs.matchWorkspaces(filePaths, patterns);
 
         if (found.length) {
           matches.push(current);

--- a/src/__fixtures__/nested-workspaces-transitive-dependents/packages/workspace-a/package.json
+++ b/src/__fixtures__/nested-workspaces-transitive-dependents/packages/workspace-a/package.json
@@ -2,7 +2,9 @@
   "name": "workspace-a",
   "private": true,
   "version": "1.0.0",
-  "workspaces": ["packages/*"],
+  "bolt": {
+    "workspaces": ["packages/*"]
+  },
   "dependencies": {
     "react": "^15.6.1",
     "pkg-a": "^1.0.0"

--- a/src/__fixtures__/nested-workspaces-with-scoped-package-names/packages/foo/package.json
+++ b/src/__fixtures__/nested-workspaces-with-scoped-package-names/packages/foo/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@scope/foo",
   "version": "1.0.0",
-  "workspaces": ["packages/*"],
+  "bolt": {
+    "workspaces": ["packages/*"]  
+  },
   "dependencies": {
     "react": "^15.6.1",
     "bar": "^1.0.0"

--- a/src/__fixtures__/nested-workspaces/packages/foo/package.json
+++ b/src/__fixtures__/nested-workspaces/packages/foo/package.json
@@ -1,7 +1,9 @@
 {
   "name": "foo",
   "version": "1.0.0",
-  "workspaces": ["packages/*"],
+  "bolt": {
+    "workspaces": ["packages/*"]
+  },
   "dependencies": {
     "react": "^15.6.1",
     "bar": "^1.0.0"

--- a/src/__tests__/Config.test.js
+++ b/src/__tests__/Config.test.js
@@ -113,14 +113,17 @@ describe('getProjectConfig()', () => {
     expect(found).toBe(null);
   });
 
-  it('should get the root if in nested package not included in a parent project', async () => {
-    let fixturePath = await getFixturePath(
-      __dirname,
-      'simple-project-with-excluded-package',
-      'packages',
-      'bar'
-    );
-    let found = await Config.getProjectConfig(fixturePath);
-    expect(found).toBe(path.join(fixturePath, 'package.json'));
-  });
+  it.only(
+    'should get the root if in nested package not included in a parent project',
+    async () => {
+      let fixturePath = await getFixturePath(
+        __dirname,
+        'simple-project-with-excluded-package',
+        'packages',
+        'bar'
+      );
+      let found = await Config.getProjectConfig(fixturePath);
+      expect(found).toBe(path.join(fixturePath, 'package.json'));
+    }
+  );
 });

--- a/src/utils/globs.js
+++ b/src/utils/globs.js
@@ -1,0 +1,30 @@
+// @flow
+import multimatch from 'multimatch';
+import globby from 'globby';
+import * as path from 'path';
+
+function matchGlobs(paths: Array<string>, patterns: Array<string>) {
+  return multimatch(paths, patterns);
+}
+
+function findGlobs(cwd: string, patterns: Array<string>) {
+  return globby(patterns, { cwd });
+}
+
+export function matchWorkspaces(paths: Array<string>, patterns: Array<string>) {
+  return matchGlobs(paths, patterns);
+}
+
+export function findWorkspaces(cwd: string, patterns: Array<string>) {
+  return findGlobs(cwd, patterns);
+}
+
+export function matchOnlyAndIgnore(
+  paths: Array<string>,
+  only: string | void,
+  ignore: string | void
+) {
+  let onlyPattern = only || '**';
+  let ignorePattern = ignore ? `!${ignore}` : '';
+  return matchGlobs(paths, [onlyPattern, ignorePattern]);
+}


### PR DESCRIPTION
This changes the way workspaces are specified to work of the cwd of the package that specifies them:

```json
{
  "pworkspaces": [
    "foo"
  ]
}
```

Previously would match:

```
/project/foo
/project/nested/dir/foo
```

But will now only match

```
/project/foo
```

Also creates a new `globs` util to use instead of `multimatch` or `globby` directly.

---

Edit: all of the above was incorrect, I just had made a dumb mistake in `getWorkspaces()`