### PR TITLE
Rework messages/logger to use opaque type, add emojis, rework running scripts to add message

### DIFF
--- a/src/Project.js
+++ b/src/Project.js
@@ -181,7 +181,7 @@ export default class Project {
     );
 
     if (filteredWorkspaces.length === 0) {
-      logger.warn('No packages match the filters provided');
+      logger.warn(messages.noPackagesMatchFilters());
     }
 
     return filteredWorkspaces;

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,7 @@
 import meow from 'meow';
 import chalk from 'chalk';
 import * as logger from './utils/logger';
+import * as messages from './utils/messages';
 import * as processes from './utils/processes';
 import { BoltError } from './utils/errors';
 import cleanStack from 'clean-stack';
@@ -396,29 +397,17 @@ export default async function cli(argv: Array<string>, exit: boolean = false) {
 
   const { pkg, input, flags } = meow({
     argv,
-    help: `
-      usage
-        $ bolt [command] <...args> <...opts>
-
-      commands
-        init         init a bolt project
-        install      install a bolt project
-        add          add a dependency to a bolt project
-        upgrade      upgrade a dependency in a bolt project
-        remove       remove a dependency from a bolt project
-        exec         execute a command in a bolt project
-        run          run a script in a bolt project
-        publish      publish all the packages in a bolt project
-        workspaces   run a bolt command inside all workspaces
-        workspace    run a bolt command inside a specific workspace
-        help         get help with bolt commands
-    `,
+    help: messages.helpContent(),
     flags: {
       '--': true
     }
   });
 
-  logger.title(`bolt v${pkg.version}`);
+  logger.title(
+    messages.boltVersion(pkg.version),
+    messages.nodeVersion(process.versions.node),
+    { emoji: '⚡️' }
+  );
 
   processes.handleSignals();
 
@@ -441,5 +430,8 @@ export default async function cli(argv: Array<string>, exit: boolean = false) {
   const timing = (Date.now() - start) / 1000;
   const rounded = Math.round(timing * 100) / 100;
 
-  logger.log(`Done in ${rounded}s.`);
+  logger.info(messages.doneInSeconds(rounded), {
+    emoji: '🏁',
+    prefix: false
+  });
 }

--- a/src/commands/normalize.js
+++ b/src/commands/normalize.js
@@ -195,6 +195,8 @@ export async function normalize(opts: NormalizeOptions) {
     }
   }
 
-  logger.error('The following packages could not be normalized:');
-  logger.log(outputItems.join('\n\n'));
+  logger.error(messages.couldNotBeNormalized());
+  logger.error(messages.toMessage(outputItems.join('\n\n')), {
+    prefix: false
+  });
 }

--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -3,6 +3,7 @@ import semver from 'semver';
 import * as options from '../utils/options';
 import { BoltError } from '../utils/errors';
 import * as logger from '../utils/logger';
+import * as messages from '../utils/messages';
 import * as locks from '../utils/locks';
 import * as npm from '../utils/npm';
 import Project from '../Project';
@@ -64,13 +65,13 @@ export async function publish(opts: PublishOptions) {
     const unpublishedWorkspaces = workspaces.filter(isUnpublished);
 
     if (unpublishedPackages.length === 0) {
-      logger.warn('No unpublished packages to release');
+      logger.warn(messages.noUnpublishedPackagesToPublish());
     }
 
     await Project.runWorkspaceTasks(unpublishedWorkspaces, async workspace => {
       const name = workspace.pkg.config.getName();
       const version = workspace.pkg.config.getVersion();
-      logger.info(`Publishing ${name} at ${version}`);
+      logger.info(messages.publishingPackage(name, version));
 
       await npm.publish(name, { cwd: workspace.pkg.dir, access: opts.access });
     });

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -2,6 +2,7 @@
 import Package from '../Package';
 import * as options from '../utils/options';
 import * as yarn from '../utils/yarn';
+import * as logger from '../utils/logger';
 import { BoltError } from '../utils/errors';
 
 export type RunOptions = {|
@@ -25,9 +26,12 @@ export function toRunOptions(
 export async function run(opts: RunOptions) {
   let cwd = opts.cwd || process.cwd();
   let pkg = await Package.closest(cwd);
-  let validScript = await yarn.run(pkg, opts.script, opts.scriptArgs);
+  let script = await yarn.getScript(pkg, opts.script);
 
-  if (!validScript) {
+  if (script) {
+    logger.cmd(script, opts.scriptArgs);
+    await yarn.run(pkg, opts.script, opts.scriptArgs);
+  } else {
     throw new BoltError(
       `Package at "${pkg.dir}" does not have a script named "${opts.script}"`
     );

--- a/src/utils/locks.js
+++ b/src/utils/locks.js
@@ -1,6 +1,7 @@
 // @flow
 import Package from '../Package';
 import * as logger from './logger';
+import * as messages from './messages';
 import * as npm from './npm';
 import { settleAll } from './promises';
 import { BoltError } from './errors';
@@ -11,7 +12,7 @@ export async function lock(packages: Array<Package>) {
   let locks = [];
   let promises = [];
 
-  logger.info('Attempting to get locks for all packages');
+  logger.info(messages.lockingAllPackages());
 
   for (let pkg of packages) {
     let name = pkg.config.getName();

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,50 +1,104 @@
 // @flow
 import chalk from 'chalk';
 import type Package from '../Package';
+import { toString, type Message } from './messages';
 
-export function prefix(prefix: string, message: string | Buffer) {
-  return message
-    .toString()
-    .trimRight()
-    .split('\n')
-    .map(line => {
-      return prefix + ' ' + line;
-    })
-    .join('\n');
-}
+type LoggerOpts = {
+  prefix?: string | false,
+  emoji?: string
+};
 
-export function log(message: string) {
-  console.log(message);
-}
+function fmt(str: Message | Buffer | string, opts: LoggerOpts = {}) {
+  let result = toString(str);
 
-export function title(message: string) {
-  console.log(chalk.bold(message));
-}
+  if (opts.prefix) {
+    let prefix = opts.prefix;
+    result = result
+      .trimRight()
+      .split('\n')
+      .map(line => `${prefix} ${line}`)
+      .join('\n');
+  }
 
-export function info(message: string) {
-  console.error(prefix(chalk.cyan('info'), message));
-}
+  if (opts.emoji) {
+    result = `${opts.emoji}  ${result}`;
+  }
 
-export function warn(message: string) {
-  console.error(prefix(chalk.yellow('warn'), message));
-}
-
-export function error(message: string) {
-  console.error(prefix(chalk.red('error'), message));
-}
-
-export function success(message: string) {
-  console.log(prefix(chalk.green('success'), message));
+  return result;
 }
 
 function prompt(pkg) {
   return (pkg ? '(' + pkg.config.getName() + ') ' : '') + '$ ';
 }
 
-export function stdout(cmd: string, data: Buffer, pkg?: Package) {
-  console.log(prefix(chalk.cyan(prompt(pkg) + cmd), data));
+function write(
+  message: Message | Buffer | string,
+  opts: LoggerOpts = {},
+  err: boolean = false
+) {
+  if (err) {
+    console.error(fmt(message, opts));
+  } else {
+    console.log(fmt(message, opts));
+  }
 }
 
-export function stderr(cmd: string, data: Buffer, pkg?: Package) {
-  console.error(prefix(chalk.red(prompt(pkg) + cmd), data));
+export function title(
+  title: Message,
+  subtitle: Message,
+  opts: LoggerOpts = {}
+) {
+  let str = chalk.bold(title);
+  if (subtitle) str += ' ' + chalk.dim(subtitle);
+  write(str, opts);
+}
+
+const INFO_PREFIX = chalk.cyan('info');
+const WARN_PREFIX = chalk.yellow('warn');
+const ERROR_PREFIX = chalk.red('error');
+const SUCCESS_PREFIX = chalk.green('success');
+
+export function info(message: Message, opts: LoggerOpts = {}) {
+  write(message, { prefix: INFO_PREFIX, ...opts }, true);
+}
+
+export function warn(message: Message, opts: LoggerOpts = {}) {
+  write(message, { prefix: WARN_PREFIX, ...opts }, true);
+}
+
+export function error(message: Message, opts: LoggerOpts = {}) {
+  write(message, { prefix: ERROR_PREFIX, ...opts }, true);
+}
+
+export function success(message: Message, opts: LoggerOpts = {}) {
+  write(message, { prefix: SUCCESS_PREFIX, ...opts }, true);
+}
+
+export function stdout(
+  cmd: string,
+  data: Buffer,
+  pkg?: Package,
+  opts: LoggerOpts = {}
+) {
+  let prefix = chalk.cyan(prompt(pkg) + cmd);
+  write(data, { prefix, ...opts }, false);
+}
+
+export function stderr(
+  cmd: string,
+  data: Buffer,
+  pkg?: Package,
+  opts: LoggerOpts = {}
+) {
+  let prefix = chalk.red(prompt(pkg) + cmd);
+  write(data, { prefix, ...opts }, true);
+}
+
+export function cmd(cmd: string, args: Array<string>, opts: LoggerOpts = {}) {
+  let msg = chalk.dim(prompt() + cmd);
+  if (args.length) {
+    msg += ' ';
+    msg += chalk.magenta(args.join(' '));
+  }
+  write(msg, {}, true);
 }

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -2,6 +2,18 @@
 import chalk from 'chalk';
 import type Workspace from '../Workspace';
 
+/*::
+export opaque type Message = string;
+*/
+
+export function toString(message: Message | Buffer | string): string {
+  return message.toString();
+}
+
+export function toMessage(str: string): Message {
+  return str;
+}
+
 function normalPkg(str: string) {
   return chalk.cyan(`"${str}"`);
 }
@@ -23,7 +35,7 @@ export function packageMustDependOnCurrentVersion(
   depName: string,
   expected: string,
   actual: string
-) {
+): Message {
   return `Package ${normalPkg(
     name
   )} must depend on the current version of ${normalPkg(depName)}: ${goodVer(
@@ -31,7 +43,10 @@ export function packageMustDependOnCurrentVersion(
   )} vs ${badVer(actual)}`;
 }
 
-export function depMustBeAddedToProject(pkgName: string, depName: string) {
+export function depMustBeAddedToProject(
+  pkgName: string,
+  depName: string
+): Message {
   return `Package ${normalPkg(pkgName)} dependency ${normalPkg(
     depName
   )} must be added to project dependencies.`;
@@ -42,7 +57,7 @@ export function depMustMatchProject(
   depName: string,
   expected: string,
   actual: string
-) {
+): Message {
   return `Package ${normalPkg(pkgName)} dependency ${normalPkg(
     depName
   )} must match version in project dependencies. ${goodVer(
@@ -54,7 +69,7 @@ export function unableToUpdateDepVersion(
   pkgName: string,
   depName: string,
   version: string
-) {
+): Message {
   return `Unable to update package ${normalPkg(pkgName)} dependency ${normalPkg(
     depName
   )} to version ${goodVer(version)}`;
@@ -64,7 +79,7 @@ export function addedPackageDependency(
   pkgName: string,
   depName: string,
   versionRange: string
-) {
+): Message {
   return `Added package ${normalPkg(pkgName)} dependency ${normalPkg(
     depName
   )} at version ${goodVer(versionRange)}`;
@@ -75,13 +90,16 @@ export function updatedPackageDependency(
   depName: string,
   versionRange: string,
   prevVersionRange: string
-) {
+): Message {
   return `Updated package ${normalPkg(pkgName)} dependency ${normalPkg(
     depName
   )} to version ${goodVer(versionRange)} from ${badVer(prevVersionRange)}`;
 }
 
-export function removedPackageDependency(pkgName: string, depName: string) {
+export function removedPackageDependency(
+  pkgName: string,
+  depName: string
+): Message {
   return `Removed package ${normalPkg(pkgName)} dependency ${normalPkg(
     depName
   )}`;
@@ -90,20 +108,20 @@ export function removedPackageDependency(pkgName: string, depName: string) {
 export function unableToNormalizeVersionRanges(
   depName: string,
   versionDetails: string
-) {
+): Message {
   return `Unable to normalize ${normalPkg(
     depName
   )} for version ranges: ${versionDetails}`;
 }
 
-export function dependencyNotInstalled(depName: string) {
+export function dependencyNotInstalled(depName: string): Message {
   return `You do not have a dependency named ${normalPkg(depName)} installed.`;
 }
 
 export function cannotRemoveDependencyDependendOnByWorkspaces(
   depName: string,
   workspaces: Array<Workspace>
-) {
+): Message {
   return `Cannot remove dependency ${normalPkg(
     depName
   )} that is depended on by some workspaces:\n${workspaces
@@ -111,14 +129,121 @@ export function cannotRemoveDependencyDependendOnByWorkspaces(
     .join('\n')}`;
 }
 
-export function runWorkspacesRemoveDependency(depName: string) {
+export function runWorkspacesRemoveDependency(depName: string): Message {
   return `Run ${cmd(
     `bolt workspaces remove ${depName}`
   )} to remove from all workspaces`;
 }
 
-export function couldntRemoveDependencies(deps: Array<string>) {
+export function couldntRemoveDependencies(deps: Array<string>): Message {
   return `Could not remove dependencies:\n${deps
     .map(depName => ` - ${normalPkg(depName)}`)
     .join('\n')}`;
+}
+
+export function doneInSeconds(rounded: number): Message {
+  return `Done in ${rounded}s.`;
+}
+
+export function boltVersion(version: string): Message {
+  return `bolt v${version}`;
+}
+
+export function nodeVersion(version: string): Message {
+  return `(node v${version})`;
+}
+
+export function helpContent(): string {
+  return `
+    usage
+      $ bolt [command] <...args> <...opts>
+
+    commands
+      init         init a bolt project
+      install      install a bolt project
+      add          add a dependency to a bolt project
+      upgrade      upgrade a dependency in a bolt project
+      remove       remove a dependency from a bolt project
+      exec         execute a command in a bolt project
+      run          run a script in a bolt project
+      publish      publish all the packages in a bolt project
+      workspaces   run a bolt command inside all workspaces
+      workspace    run a bolt command inside a specific workspace
+      help         get help with bolt commands
+  `;
+}
+
+export function noPackagesMatchFilters(): Message {
+  return 'No packages match the filters provided';
+}
+
+export function removedDependencies(): Message {
+  return 'Removed dependencies';
+}
+
+export function npmPackageCouldNotBeFound(pkgName: string): Message {
+  return `Package named ${normalPkg(
+    pkgName
+  )} could not be found, this could mean you have not published this package yet`;
+}
+
+export function notDistTagFound(tagName: string, pkgName: string): Message {
+  return `No dist tag ${normalPkg(tagName)} found for package ${normalPkg(
+    pkgName
+  )}`;
+}
+
+export function npmDistTagRm(tagName: string, pkgName: string): Message {
+  return `npm dist-tag rm ${pkgName} ${tagName}`;
+}
+
+export function npmDistTagAdd(
+  pkgName: string,
+  pkgVersion: string,
+  tagName: string
+): Message {
+  return `npm dist-tag add ${pkgName}@${pkgVersion} ${tagName}`;
+}
+
+export function npmPublish(pkgName: string): Message {
+  return `npm publish ${pkgName}`;
+}
+
+export function npmInfo(pkgName: string): Message {
+  return `npm info ${pkgName}`;
+}
+
+export function npmInfo404(pkgName: string): Message {
+  return `Recieved 404 for npm info ${normalPkg(pkgName)}`;
+}
+
+export function lockingAllPackages(): Message {
+  return 'Attempting to get locks for all packages';
+}
+
+export function installingProjectDependencies(): Message {
+  return '[1/2] Installing project dependencies...';
+}
+
+export function linkingWorkspaceDependencies(): Message {
+  return '[2/2] Linking workspace dependencies...';
+}
+
+export function publishingPackage(
+  pkgName: string,
+  pkgVersion: string
+): Message {
+  return `Publishing ${normalPkg(pkgName)} at ${goodVer(pkgVersion)}`;
+}
+
+export function noUnpublishedPackagesToPublish(): Message {
+  return 'No unpublished packages to publish';
+}
+
+export function couldNotBeNormalized(): Message {
+  return 'The following packages could not be normalized:';
+}
+
+export function installedAndLinkedWorkspaces(): Message {
+  return 'Installed and linked workspaces.';
 }

--- a/src/utils/npm.js
+++ b/src/utils/npm.js
@@ -1,6 +1,7 @@
 // @flow
 import { BoltError } from './errors';
 import * as logger from './logger';
+import * as messages from './messages';
 import * as processes from './processes';
 import pLimit from 'p-limit';
 
@@ -8,7 +9,7 @@ const npmRequestLimit = pLimit(40);
 
 export function info(pkgName: string) {
   return npmRequestLimit(async () => {
-    logger.info(`npm info ${pkgName}`);
+    logger.info(messages.npmInfo(pkgName));
 
     const result = await processes.spawn('npm', ['info', pkgName, '--json'], {
       silent: true
@@ -24,7 +25,7 @@ export async function infoAllow404(pkgName: string) {
     return { published: true, pkgInfo };
   } catch (error) {
     if (error.stderr && error.stderr.startsWith('npm ERR! code E404')) {
-      logger.warn(`Recieved 404 for npm info ${pkgName}`);
+      logger.warn(messages.npmInfo404(pkgName));
       return { published: false, pkgInfo: {} };
     }
     throw error;
@@ -36,10 +37,8 @@ export function publish(
   opts: { cwd?: string, access?: string } = {}
 ) {
   return npmRequestLimit(async () => {
-    logger.info(`npm publish ${pkgName}`);
-
-    const publishFlags = opts.access ? ['--access', opts.access] : [];
-
+    logger.info(messages.npmPublish(pkgName));
+    let publishFlags = opts.access ? ['--access', opts.access] : [];
     return await processes.spawn('npm', ['publish', ...publishFlags], {
       cwd: opts.cwd
     });
@@ -48,15 +47,9 @@ export function publish(
 
 export function addTag(pkgName: string, pkgVersion: string, tag: string) {
   return npmRequestLimit(async () => {
-    const pkgStr = `${pkgName}@${pkgVersion}`;
-    logger.info(`npm dist-tag add ${pkgStr} ${tag}`);
-
-    const result = await processes.spawn('npm', [
-      'dist-tag',
-      'add',
-      pkgStr,
-      tag
-    ]);
+    logger.info(messages.npmDistTagAdd(pkgName, pkgVersion, tag));
+    let pkgStr = `${pkgName}@${pkgVersion}`;
+    let result = await processes.spawn('npm', ['dist-tag', 'add', pkgStr, tag]);
     // An existing tag will return a warning to stderr, but a 0 status code
     if (result.stderr) {
       throw new BoltError(
@@ -69,7 +62,7 @@ export function addTag(pkgName: string, pkgVersion: string, tag: string) {
 
 export function removeTag(pkgName: string, tag: string) {
   return npmRequestLimit(async () => {
-    logger.info(`npm dist-tag rm ${pkgName} ${tag}`);
+    logger.info(messages.npmDistTagRm(pkgName, tag));
 
     try {
       return await processes.spawn('npm', ['dist-tag', 'rm', pkgName, tag], {
@@ -78,16 +71,14 @@ export function removeTag(pkgName: string, tag: string) {
     } catch (error) {
       // The dist tag not existing is unexpected, but shouldn't prevent execution
       if (error.code === 1 && error.stderr.includes('is not a dist-tag on')) {
-        logger.warn(`No dist tag "${tag}" found for package ${pkgName}`);
+        logger.warn(messages.notDistTagFound(tag, pkgName));
         return;
       } else if (
         error.stderr &&
         error.stderr.startsWith('npm ERR! code E404')
       ) {
         // the package does not exist yet, warn but dont error
-        logger.warn(
-          `Package: ${pkgName} could not be found, this could mean you have not published this package yet`
-        );
+        logger.warn(messages.npmPackageCouldNotBeFound(pkgName));
         return;
       }
       throw error;

--- a/src/utils/removeDependenciesFromPackages.js
+++ b/src/utils/removeDependenciesFromPackages.js
@@ -157,5 +157,5 @@ export default async function removeDependenciesFromPackages(
     await removeDependenciesFromPackage(project, workspace.pkg, dependencies);
   }
 
-  logger.success('Removed dependencies');
+  logger.success(messages.removedDependencies());
 }


### PR DESCRIPTION
You are now forced to write:

```js
logger.error(messages.didntWork())
```

This will cause a type error:

```js
logger.error(`Didn't work`);
// string. This type is incompatible with the expected param type of opaque type `Message`
```

I also added a bunch of emojis to the CLI, and I split out some logic from `yarn.run` to `yarn.getScript` so we could add messages for missing scripts elsewhere.


