### PR TITLE
Adds yarn.runIfExists

### DIFF
--- a/src/commands/__tests__/install.test.js
+++ b/src/commands/__tests__/install.test.js
@@ -80,9 +80,10 @@ describe('install', () => {
     await install(toInstallOptions([], { cwd }));
 
     for (let workspace of workspaces) {
-      expect(unsafeYarn.run).toHaveBeenCalledWith(workspace.pkg, 'preinstall');
-      expect(unsafeYarn.run).toHaveBeenCalledWith(workspace.pkg, 'postinstall');
-      expect(unsafeYarn.run).toHaveBeenCalledWith(workspace.pkg, 'prepublish');
+      const runFn = unsafeYarn.runIfExists;
+      expect(runFn).toHaveBeenCalledWith(workspace.pkg, 'preinstall');
+      expect(runFn).toHaveBeenCalledWith(workspace.pkg, 'postinstall');
+      expect(runFn).toHaveBeenCalledWith(workspace.pkg, 'prepublish');
     }
   });
 

--- a/src/commands/workspaces/run.js
+++ b/src/commands/workspaces/run.js
@@ -34,6 +34,7 @@ export async function workspacesRun(opts: WorkspacesRunOptions) {
   );
 
   await Project.runWorkspaceTasks(filteredWorkspaces, async workspace => {
-    await yarn.run(workspace.pkg, opts.script, opts.scriptArgs);
+    // no need to error if script doesn't exist
+    await yarn.runIfExists(workspace.pkg, opts.script, opts.scriptArgs);
   });
 }

--- a/src/utils/__tests__/symlinkPackageDependencies.test.js
+++ b/src/utils/__tests__/symlinkPackageDependencies.test.js
@@ -94,8 +94,8 @@ describe('utils/symlinkPackageDependencies()', () => {
     it('should run correct lifecycle scripts', async () => {
       await symlinkPackageDependencies(project, pkgToSymlink, ['bar']);
 
-      expect(yarn.run).toHaveBeenCalledTimes(4);
-      const yarnCalls = unsafeYarn.run.mock.calls;
+      expect(yarn.runIfExists).toHaveBeenCalledTimes(4);
+      const yarnCalls = unsafeYarn.runIfExists.mock.calls;
       expect(yarnCalls[0][1]).toEqual('preinstall');
       expect(yarnCalls[1][1]).toEqual('postinstall');
       expect(yarnCalls[2][1]).toEqual('prepublish');

--- a/src/utils/removeDependenciesFromPackages.js
+++ b/src/utils/removeDependenciesFromPackages.js
@@ -142,9 +142,7 @@ export default async function removeDependenciesFromPackages(
   await Promise.all(
     UNINSTALL_SCRIPTS.map(async script => {
       await Project.runWorkspaceTasks(includedWorkspaces, async workspace => {
-        if (await yarn.getScript(workspace.pkg, script)) {
-          await yarn.run(workspace.pkg, script);
-        }
+        await yarn.runIfExists(workspace.pkg, script);
       });
     })
   );

--- a/src/utils/symlinkPackageDependencies.js
+++ b/src/utils/symlinkPackageDependencies.js
@@ -200,7 +200,7 @@ export default async function symlinkPackageDependencies(
    * Create directories and symlinks *
   ***********************************/
 
-  await yarn.run(pkg, 'preinstall');
+  await yarn.runIfExists(pkg, 'preinstall');
 
   await Promise.all(
     directoriesToCreate.map(dirName => {
@@ -214,7 +214,7 @@ export default async function symlinkPackageDependencies(
     })
   );
 
-  await yarn.run(pkg, 'postinstall');
-  await yarn.run(pkg, 'prepublish');
-  await yarn.run(pkg, 'prepare');
+  await yarn.runIfExists(pkg, 'postinstall');
+  await yarn.runIfExists(pkg, 'prepublish');
+  await yarn.runIfExists(pkg, 'prepare');
 }

--- a/src/utils/yarn.js
+++ b/src/utils/yarn.js
@@ -62,6 +62,17 @@ export async function run(
   });
 }
 
+export async function runIfExists(
+  pkg: Package,
+  script: string,
+  args: Array<string> = []
+) {
+  const scriptExists = await getScript(pkg, script);
+  if (scriptExists) {
+    await run(pkg, script, args);
+  }
+}
+
 export async function getScript(pkg: Package, script: string) {
   let result = null;
   let scripts = pkg.config.getScripts();


### PR DESCRIPTION
I introduced a regression with the bolt add when I refactored the install script to use my symlinkPakckages helper.

I've added `yarn.runIfExists` to wrap the behaviour where you dont want to error if the script doesnt exist. So, things like lifecycle events and `workspaces run`.
