### PR TITLE
Make JSON parser errors easier to identify

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -85,7 +85,6 @@ export default class Config {
           emoji: '💥',
           prefix: false
         });
-        // logger.error(filePath, { emoji: '💥', prefix: false });
       }
       throw e;
     }

--- a/src/Config.js
+++ b/src/Config.js
@@ -6,6 +6,8 @@ import type { JSONValue, DependencySet } from './types';
 import * as fs from './utils/fs';
 import * as path from 'path';
 import * as globs from './utils/globs';
+import * as logger from './utils/logger';
+import * as messages from './utils/messages';
 import { BoltError } from './utils/errors';
 
 async function getPackageStack(cwd: string) {
@@ -74,8 +76,19 @@ export default class Config {
   constructor(filePath: string, fileContents: string) {
     this.filePath = filePath;
     this.fileContents = fileContents;
-    this.indent = detectIndent(fileContents).indent || '  ';
-    this.json = parseJson(fileContents);
+    try {
+      this.indent = detectIndent(fileContents).indent || '  ';
+      this.json = parseJson(fileContents);
+    } catch (e) {
+      if (e.name === 'JSONError') {
+        logger.error(messages.errorParsingJSON(filePath), {
+          emoji: '💥',
+          prefix: false
+        });
+        // logger.error(filePath, { emoji: '💥', prefix: false });
+      }
+      throw e;
+    }
   }
 
   static async findConfigFile(filePath: string): Promise<?string> {

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -11,17 +11,18 @@ type LoggerOpts = {
 function fmt(str: Message | Buffer | string, opts: LoggerOpts = {}) {
   let result = toString(str);
 
-  if (opts.prefix) {
-    let prefix = opts.prefix;
+  let prefix = opts.prefix || '';
+
+  if (opts.emoji) {
+    prefix = `${opts.emoji}  ${prefix}`;
+  }
+
+  if (prefix) {
     result = result
       .trimRight()
       .split('\n')
       .map(line => `${prefix} ${line}`)
       .join('\n');
-  }
-
-  if (opts.emoji) {
-    result = `${opts.emoji}  ${result}`;
   }
 
   return result;

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -259,3 +259,7 @@ export function installedAndLinkedWorkspaces(): Message {
 export function cannotInstallWorkspaceInProject(pkgName: string): Message {
   return `Cannot install workspace "${pkgName}" as a dependency of a project`;
 }
+
+export function errorParsingJSON(filePath: string): Message {
+  return `Error parsing JSON in file:\n${filePath}`;
+}


### PR DESCRIPTION
This PR does two things:

- Fixes the logger rendering of emoji so they are prefixed to each line, not just the first line
- Displays a helpful error message indicating which json file had an error when `parse-json` throws an error of type `JSONError`

The second fix means that if you have a syntax error in one of your `package.json` files, it will now tell you which one.