### PR TITLE
Better errors with missing package.json

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -95,7 +95,15 @@ export default class Config {
   }
 
   static async init(filePath: string): Promise<Config> {
-    let fileContents = await fs.readFile(filePath);
+    let fileContents;
+    try {
+      fileContents = await fs.readFile(filePath);
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        logger.error(messages.cannotInitConfigMissingPkgJSON(filePath));
+      }
+      throw e;
+    }
     return new Config(filePath, fileContents.toString());
   }
 

--- a/src/Package.js
+++ b/src/Package.js
@@ -29,7 +29,7 @@ export default class Package {
   static async init(filePath: string) {
     let config = await Config.init(filePath);
     if (!config) {
-      throw new BoltError(`Could not find package.json in ${filePath}`);
+      throw new BoltError(`Could not init config for "${filePath}"`);
     }
     return new Package(filePath, config);
   }

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -263,3 +263,12 @@ export function cannotInstallWorkspaceInProject(pkgName: string): Message {
 export function errorParsingJSON(filePath: string): Message {
   return `Error parsing JSON in file:\n${filePath}`;
 }
+
+export function cannotInitConfigMissingPkgJSON(filePath: string): Message {
+  const basePath = filePath.replace(/.package\.json$/, '');
+  return `This folder does not contain a package.json:\n${basePath}
+
+Sometimes this is caused by incomplete packages or switching branches.
+
+Try removing the directory or fixing the package and run bolt again.`;
+}


### PR DESCRIPTION
I found this problem after switching branches in a bolt repo, where an empty package directory had been left behind because it had an ignored `node_modules` in it.

The default "could not find package.json" error (code `ENOENT`) was really unhelpful, because I didn't realise the directory remained, and couldn't find any code referencing the missing file.

I added a nicer error message so that if (when) this happens to others, they understand why it may have happened and how to resolve it.