### PR TITLE
Updates bolt.updatePackageVersions to not automatically add a caret

### DIFF
--- a/src/functions/__tests__/updatePackageVersions.test.js
+++ b/src/functions/__tests__/updatePackageVersions.test.js
@@ -33,7 +33,7 @@ describe('function/updatePackageVersions', () => {
       expect(await getDepVersion(barPath, 'react')).toBe('^15.6.1');
       expect(await getDepVersion(bazPath, 'react')).toBe('^15.6.1');
 
-      await updatePackageVersions({ react: '15.6.0' }, { cwd });
+      await updatePackageVersions({ react: '^15.6.0' }, { cwd });
 
       expect(await getDepVersion(fooPath, 'react')).toBe('^15.6.0');
       expect(await getDepVersion(barPath, 'react')).toBe('^15.6.0');
@@ -59,7 +59,7 @@ describe('function/updatePackageVersions', () => {
       expect(await getDepVersion(fooPath, 'react')).toBe('^15.6.1');
       expect(await getDepVersion(fooPath, 'bar')).toBe('^1.0.0');
 
-      await updatePackageVersions({ react: '15.6.0', bar: '1.0.1' }, { cwd });
+      await updatePackageVersions({ react: '^15.6.0', bar: '^1.0.1' }, { cwd });
 
       expect(await getDepVersion(fooPath, 'react')).toBe('^15.6.0');
       expect(await getDepVersion(fooPath, 'bar')).toBe('^1.0.1');
@@ -79,7 +79,7 @@ describe('function/updatePackageVersions', () => {
       '^16.0.0'
     );
 
-    await updatePackageVersions({ react: '15.6.0' }, { cwd });
+    await updatePackageVersions({ react: '^15.6.0' }, { cwd });
 
     expect(await getDepVersion(fooPath, 'react', 'devDependencies')).toBe(
       '^15.6.0'

--- a/src/functions/updatePackageVersions.js
+++ b/src/functions/updatePackageVersions.js
@@ -10,6 +10,9 @@ type Options = {
   cwd?: string
 };
 
+/**
+ * Updates all dependency versions
+ */
 export default async function updatePackageVersions(
   versions: VersionMap,
   opts: Options = {}
@@ -30,7 +33,7 @@ export default async function updatePackageVersions(
         await pkg.setDependencyVersionRange(
           depName,
           depType,
-          '^' + versions[depName]
+          versions[depName]
         );
       }
       updatedPackages.add(pkg.filePath);


### PR DESCRIPTION
As in title. This is to allow us to bump internal versions only when required.

Note: This is a breaking change from current API.