### PR TITLE
Changes updatePackageVersions to work with ranges

### DIFF
--- a/src/functions/__fixtures__/lots-of-internally-linked-deps/package.json
+++ b/src/functions/__fixtures__/lots-of-internally-linked-deps/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "version": "1.0.0",
+  "name": "lots-of-internally-linked-deps",
+  "description": "all packages are at 1.1.1, each named package is depended on according to that name",
+  "description-2": "i.e caret-dep will always dep depended on with a caret range",
+  "bolt": {
+    "workspaces": ["packages/*"]
+  },
+  "dependencies": {
+    "react": "^15.6.1",
+    "left-pad": "^1.1.3"
+  }
+}

--- a/src/functions/__fixtures__/lots-of-internally-linked-deps/packages/caret-dep/package.json
+++ b/src/functions/__fixtures__/lots-of-internally-linked-deps/packages/caret-dep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "caret-dep",
+  "version": "1.1.1",
+  "dependencies": {
+    "react": "^15.6.1"
+  }
+}

--- a/src/functions/__fixtures__/lots-of-internally-linked-deps/packages/has-all-deps-with-peers/package.json
+++ b/src/functions/__fixtures__/lots-of-internally-linked-deps/packages/has-all-deps-with-peers/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "has-all-deps-with-peers",
+  "version": "1.1.1",
+  "peerDependencies": {
+    "pinned-dep": "1.1.1",
+    "tilde-dep": "~1.1.1",
+    "caret-dep": "^1.1.1"
+  },
+  "devDependencies": {
+    "pinned-dep": "1.1.1",
+    "tilde-dep": "~1.1.1",
+    "caret-dep": "^1.1.1"
+  }
+}

--- a/src/functions/__fixtures__/lots-of-internally-linked-deps/packages/has-all-deps/package.json
+++ b/src/functions/__fixtures__/lots-of-internally-linked-deps/packages/has-all-deps/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "has-all-deps",
+  "version": "1.1.1",
+  "dependencies": {
+    "react": "^15.6.1",
+    "pinned-dep": "1.1.1",
+    "caret-dep": "^1.1.1",
+    "tilde-dep": "~1.1.1"
+  }
+}

--- a/src/functions/__fixtures__/lots-of-internally-linked-deps/packages/pinned-dep/package.json
+++ b/src/functions/__fixtures__/lots-of-internally-linked-deps/packages/pinned-dep/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pinned-dep",
+  "version": "1.1.1",
+  "dependencies": {
+    "react": "^15.6.1",
+    "caret-dep": "^1.1.1"
+  }
+}

--- a/src/functions/__fixtures__/lots-of-internally-linked-deps/packages/tilde-dep/package.json
+++ b/src/functions/__fixtures__/lots-of-internally-linked-deps/packages/tilde-dep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "tilde-dep",
+  "version": "1.1.1",
+  "dependencies": {
+    "react": "^15.6.1"
+  }
+}

--- a/src/functions/updatePackageVersions.js
+++ b/src/functions/updatePackageVersions.js
@@ -1,6 +1,8 @@
 // @flow
 import Project from '../Project';
 import Workspace from '../Workspace';
+import * as logger from '../utils/logger';
+import * as messages from '../utils/messages';
 
 type VersionMap = {
   [name: string]: string
@@ -10,8 +12,23 @@ type Options = {
   cwd?: string
 };
 
+function versionRangeToRangeType(versionRange: string) {
+  if (versionRange.charAt(0) === '^') return '^';
+  if (versionRange.charAt(0) === '~') return '~';
+  return '';
+}
+
 /**
- * Updates all dependency versions
+ * This function is used to update all the internal dependencies where you have an external source
+ * bumping versions (a tool like bolt-releases for example).
+ * It takes an object of packageNames and their new versions. updatePackageVersions will update all
+ * internal versions of packages according to those new versions.
+ * ie, a caret dep, will remain a caret dep and a pinned dep will remain pinned.
+ *
+ * It is up to the consumer to ensure that these new versions are not going to leave the repo in an
+ * inconsistent state (internal deps leaving semver ranges).
+ *
+ * Note: we explicitly ignore all external dependencies passed and warn if they are.
  */
 export default async function updatePackageVersions(
   versions: VersionMap,
@@ -20,21 +37,31 @@ export default async function updatePackageVersions(
   let cwd = opts.cwd || process.cwd();
   let project = await Project.init(cwd);
   let workspaces = await project.getWorkspaces();
+  let { graph } = await project.getDependencyGraph(workspaces);
   let updatedPackages = new Set();
+
+  const internalDeps = Object.keys(versions).filter(dep => graph.has(dep));
+  const externalDeps = Object.keys(versions).filter(dep => !graph.has(dep));
+
+  if (externalDeps.length !== 0) {
+    logger.warn(
+      messages.externalDepsPassedToUpdatePackageVersions(externalDeps)
+    );
+  }
 
   for (let workspace of workspaces) {
     let pkg = workspace.pkg;
     let promises = [];
 
-    for (let depName of Object.keys(versions)) {
-      let depTypes = pkg.getDependencyTypes(depName);
+    for (let depName of internalDeps) {
+      const depRange = String(pkg.getDependencyVersionRange(depName));
+      const depTypes = pkg.getDependencyTypes(depName);
+      const rangeType = versionRangeToRangeType(depRange);
+      const newDepRange = rangeType + versions[depName];
+
       if (depTypes.length === 0) continue;
       for (let depType of depTypes) {
-        await pkg.setDependencyVersionRange(
-          depName,
-          depType,
-          versions[depName]
-        );
+        await pkg.setDependencyVersionRange(depName, depType, newDepRange);
       }
       updatedPackages.add(pkg.filePath);
     }

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -143,6 +143,13 @@ export function cannotRemoveDependencyDependendOnByWorkspaces(
     .map(workspace => ` - ${normalPkg(workspace.pkg.config.getName())}`)
     .join('\n')}`;
 }
+export function externalDepsPassedToUpdatePackageVersions(
+  externalDeps: Array<string>
+): Message {
+  return `Attempted to pass external dependencies to updatePackageVersions:\n${externalDeps.join(
+    ', '
+  )}`;
+}
 
 export function runWorkspacesRemoveDependency(depName: string): Message {
   return `Run ${cmd(


### PR DESCRIPTION
* updatePackageVersions now supports bumping packages with caret and tilde ranges
* BREAKING: it will no longer support bumping external deps and will warn if you attempt to

We could rename this at some point, but I think this greatly simplifies the functions purpose:
"An external tool has bumped your versions, run this function to get all your internal versions back in to line"

It should be noted though, it only bumps the ones you've told it to, and doesnt perform any validation of what you've passed in, besides excluding  external deps.