### PR TITLE
Pass pkg to processes.spawn from execCommand

### DIFF
--- a/src/utils/execCommand.js
+++ b/src/utils/execCommand.js
@@ -26,6 +26,7 @@ export default async function execCommand(
   let PATH = PATH_PARTS.join(':');
 
   return await processes.spawn(command, commandArgs, {
+    pkg,
     cwd: pkg.dir,
     tty: false,
     env: { ...process.env, PATH }


### PR DESCRIPTION
Before:
```sh
$ tsc --project ./build/es5 src/ui/MediaItem/MediaComponent.tsx(237,27): error TS2339: Property 'src' does not exist on type 'Blob'.
```

After: 
```sh
(@atlaskit/editor-common) $ tsc --project ./build/es5 src/ui/MediaItem/MediaComponent.tsx(237,27): error TS2339: Property 'src' does not exist on type 'Blob'.
```