### PR TITLE
Adding Project add <dependency>

### DIFF
--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -6,6 +6,7 @@ import * as logger from '../utils/logger';
 import addDependenciesToPackage from '../utils/addDependenciesToPackages';
 import type { Dependency, configDependencyType } from '../types';
 import { DEPENDENCY_TYPE_FLAGS_MAP } from '../constants';
+import { ProjectAddOptions } from './project/add';
 
 export type AddOptions = {
   cwd?: string,
@@ -42,7 +43,7 @@ export function toAddOptions(
   };
 }
 
-export async function add(opts: AddOptions) {
+export async function add(opts: AddOptions | ProjectAddOptions) {
   let cwd = opts.cwd || process.cwd();
   let project = await Project.init(cwd);
   let pkg = await Package.closest(cwd);

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -6,7 +6,7 @@ import * as logger from '../utils/logger';
 import addDependenciesToPackage from '../utils/addDependenciesToPackages';
 import type { Dependency, configDependencyType } from '../types';
 import { DEPENDENCY_TYPE_FLAGS_MAP } from '../constants';
-import { ProjectAddOptions } from './project/add';
+import type { ProjectAddOptions } from './project/add';
 
 export type AddOptions = {
   cwd?: string,

--- a/src/commands/project/__tests__/add.test.js
+++ b/src/commands/project/__tests__/add.test.js
@@ -1,4 +1,23 @@
 // @flow
 import { projectAdd, toProjectAddOptions } from '../add';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yarn from '../../../utils/yarn';
+import fixtures from 'fixturez';
+import addDependenciesToPackage from '../../../utils/addDependenciesToPackages';
 
-test('bolt project add');
+const f = fixtures(__dirname);
+
+jest.mock('../../../utils/addDependenciesToPackages');
+
+describe('bolt project add', () => {
+  test('adding a project dependency only used by the project', async () => {
+    let tempDir = f.copy('package-with-external-deps-installed');
+
+    await projectAdd(
+      toProjectAddOptions(['project-new-dep'], { cwd: tempDir })
+    );
+
+    expect(addDependenciesToPackage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/project/add.js
+++ b/src/commands/project/add.js
@@ -1,16 +1,49 @@
 // @flow
+import addDependenciesToPackage from '../../utils/addDependenciesToPackages';
+import Project from '../../Project';
 import * as options from '../../utils/options';
-import { BoltError } from '../../utils/errors';
+import * as logger from '../../utils/logger';
+import type { Dependency, configDependencyType } from '../../types';
+import { DEPENDENCY_TYPE_FLAGS_MAP } from '../../constants';
 
-export type ProjectAddOptions = {};
+export type ProjectAddOptions = {
+  cwd?: string,
+  deps: Array<Dependency>,
+  type: configDependencyType
+};
 
 export function toProjectAddOptions(
   args: options.Args,
   flags: options.Flags
 ): ProjectAddOptions {
-  return {};
+  const depsArgs = [];
+  let type = 'dependencies';
+
+  // args is each of our dependencies we are adding which may have "@version" parts to them
+  args.forEach(dep => {
+    depsArgs.push(options.toDependency(dep));
+  });
+
+  Object.keys(DEPENDENCY_TYPE_FLAGS_MAP).forEach(depTypeFlag => {
+    if (flags[depTypeFlag]) {
+      type = DEPENDENCY_TYPE_FLAGS_MAP[depTypeFlag];
+      // check if value of dependency flag is a package name and then push to dependency arguments
+      if (typeof flags[depTypeFlag] === 'string') {
+        depsArgs.push(options.toDependency(flags[depTypeFlag]));
+      }
+    }
+  });
+
+  return {
+    cwd: options.string(flags.cwd, 'cwd'),
+    deps: depsArgs,
+    type
+  };
 }
 
 export async function projectAdd(opts: ProjectAddOptions) {
-  throw new BoltError('Unimplemented command "project add"');
+  let cwd = opts.cwd || process.cwd();
+  let project = await Project.init(cwd);
+
+  await addDependenciesToPackage(project, project.pkg, opts.deps, opts.type);
 }

--- a/src/commands/project/add.js
+++ b/src/commands/project/add.js
@@ -5,6 +5,7 @@ import * as options from '../../utils/options';
 import * as logger from '../../utils/logger';
 import type { Dependency, configDependencyType } from '../../types';
 import { DEPENDENCY_TYPE_FLAGS_MAP } from '../../constants';
+import { add } from '../add';
 
 export type ProjectAddOptions = {
   cwd?: string,
@@ -42,8 +43,5 @@ export function toProjectAddOptions(
 }
 
 export async function projectAdd(opts: ProjectAddOptions) {
-  let cwd = opts.cwd || process.cwd();
-  let project = await Project.init(cwd);
-
-  await addDependenciesToPackage(project, project.pkg, opts.deps, opts.type);
+  await add(opts);
 }

--- a/src/utils/addDependenciesToPackages.js
+++ b/src/utils/addDependenciesToPackages.js
@@ -35,7 +35,6 @@ export default async function addDependenciesToPackage(
     // we reinitialise the project config because it will be modified externally by yarn
     project = await Project.init(project.pkg.dir);
   }
-
   if (pkg.isSamePackage(project.pkg)) {
     if (internalDeps.length > 0) {
       throw new BoltError(

--- a/src/utils/processes.js
+++ b/src/utils/processes.js
@@ -2,6 +2,7 @@
 import crossSpawn from 'cross-spawn';
 import * as logger from './logger';
 import type Package from '../Package';
+import type Project from '../Project';
 import pLimit from 'p-limit';
 import os from 'os';
 


### PR DESCRIPTION
For basic usage, this works really well, like adding the dependency. I have two questions here,

1. What do we have to do when we add the new dependency that is already present in the package? Simply install them? (into the project) I would opt for this given the fact that anybody can go into the project and install the dependencies using `yarn or npm`. 

2. Do we need to keep track of the specific project related dependencies somewhere? In order to make update to be written easier? I would say no to it, since this will create a lot of edge cases. 
 
