### PR TITLE
Makes yarn run output display relative path to yarn instead of absolute

### DIFF
--- a/src/commands/workspace/__tests__/run.test.js
+++ b/src/commands/workspace/__tests__/run.test.js
@@ -20,12 +20,14 @@ describe('bolt workspace run', () => {
   let fooWorkspaceDir;
   let barWorkspaceDir;
   let localYarn;
+  let relativeYarn;
 
   beforeEach(async () => {
     projectDir = f.copy('nested-workspaces');
     fooWorkspaceDir = path.join(projectDir, 'packages', 'foo');
     barWorkspaceDir = path.join(projectDir, 'packages', 'bar');
     localYarn = path.join(await getLocalBinPath(), 'yarn');
+    relativeYarn = path.relative(projectDir, localYarn);
   });
 
   test('running script that exists', async () => {
@@ -36,7 +38,7 @@ describe('bolt workspace run', () => {
     );
 
     expect(unsafeProcessses.spawn).toHaveBeenCalledWith(
-      localYarn,
+      relativeYarn,
       ['run', '-s', 'test'],
       expect.objectContaining({ cwd: fooWorkspaceDir })
     );
@@ -51,7 +53,7 @@ describe('bolt workspace run', () => {
 
     // Ensure the extra '--' gets passed in
     expect(unsafeProcessses.spawn).toHaveBeenCalledWith(
-      localYarn,
+      relativeYarn,
       ['run', '-s', 'test', '--', '--first-arg', '--second-arg'],
       expect.objectContaining({ cwd: fooWorkspaceDir })
     );
@@ -65,7 +67,7 @@ describe('bolt workspace run', () => {
     );
 
     expect(unsafeProcessses.spawn).toHaveBeenCalledWith(
-      localYarn,
+      relativeYarn,
       ['run', '-s', 'test'],
       expect.objectContaining({ cwd: fooWorkspaceDir })
     );

--- a/src/utils/yarn.js
+++ b/src/utils/yarn.js
@@ -4,6 +4,7 @@ import projectBinPath from 'project-bin-path';
 import * as path from 'path';
 import type { Dependency, configDependencyType } from '../types';
 import type Package from '../Package';
+import Project from '../Project';
 import * as processes from './processes';
 import * as fs from '../utils/fs';
 import * as logger from '../utils/fs';
@@ -80,14 +81,16 @@ export async function run(
   script: string,
   args: Array<string> = []
 ) {
+  const project = await Project.init(pkg.dir);
   const localYarn = path.join(await getLocalBinPath(), 'yarn');
+  // We use a relative path because the absolute paths are very long and noisy in logs
+  const localYarnRelative = path.relative(project.pkg.dir, localYarn);
   let spawnArgs = ['run', '-s', script];
 
   if (args.length) {
     spawnArgs = spawnArgs.concat('--', args);
   }
-
-  await processes.spawn(localYarn, spawnArgs, {
+  await processes.spawn(localYarnRelative, spawnArgs, {
     cwd: pkg.dir,
     pkg: pkg,
     tty: true


### PR DESCRIPTION
Output was looking like this

```
(@atlaskit/fabric) $ /usr/local/share/.config/yarn/global/node_modules/bolt/node_modules/.bin/yarn run -s release RELEASING: Releasing 1 package(s)
(@atlaskit/fabric) $ /usr/local/share/.config/yarn/global/node_modules/bolt/node_modules/.bin/yarn run -s release 
(@atlaskit/fabric) $ /usr/local/share/.config/yarn/global/node_modules/bolt/node_modules/.bin/yarn run -s release Releases:
(@atlaskit/fabric) $ /usr/local/share/.config/yarn/global/node_modules/bolt/node_modules/.bin/yarn run -s release   @atlaskit/conversation@4.6.0
(@atlaskit/fabric) $ /usr/local/share/.config/yarn/global/node_modules/bolt/node_modules/.bin/yarn run -s release 
(@atlaskit/fabric) $ /usr/local/share/.config/yarn/global/node_modules/bolt/node_modules/.bin/yarn run -s release Dependents:
```

Because it was printing the full absolute path to yarn. We didnt want to add a hack specifically for `yarn run` in processes, or add a new flag but also didnt want to pass `{silent: true}` to `run` commands as we'd lose too much information.

This is a nice happy medium, it will display the relative path to your local yarn instead

```
(@atlaskit/fabric) $ ./node_modules/.bin/yarn run -s release  ...
```