### PR TITLE
Fix executable linking issues on win32

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "flow": "flow status",
     "test": "jest --coverage",
     "format": "prettier --write src/**/*.js",
-    "build:legacy": "BABEL_ENV=legacy babel src -d dist/legacy",
-    "build:modern": "BABEL_ENV=modern babel src -d dist/modern",
+    "build:legacy": "cross-env BABEL_ENV=legacy babel src -d dist/legacy",
+    "build:modern": "cross-env BABEL_ENV=modern babel src -d dist/modern",
     "build": "yarn run clean && yarn build:legacy && yarn build:modern",
     "prepublish": "yarn build",
     "precommit": "lint-staged"
@@ -31,6 +31,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-flow": "^6.23.0",
+    "cross-env": "^5.1.3",
     "fixturez": "^1.1.0",
     "flow-bin": "^0.63.1",
     "husky": "^0.14.3",

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -49,8 +49,16 @@ function _symlink(src: string, dest: string, type: string) {
   return promisify(cb => fs.symlink(src, dest, type, cb));
 }
 
-function cmdShim(src: string, dest: string) {
-  return promisify(cb => _cmdShim(src, dest, cb));
+function stripExtension(filePath: string) {
+  return filePath.substr(0, filePath.length - path.extname(filePath).length);
+}
+
+async function cmdShim(src: string, dest: string) {
+  const currentShimTarget = path.resolve(
+    path.dirname(src),
+    await readCmdShim(src)
+  );
+  await promisify(cb => _cmdShim(currentShimTarget, stripExtension(dest), cb));
 }
 
 async function createSymbolicLink(src, dest, type) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,6 +1111,13 @@ cosmiconfig@^1.1.0:
     pinkie-promise "^2.0.0"
     require-from-string "^1.1.0"
 
+cross-env@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1912,6 +1919,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The title says it all, basically, we need to read the existing `.cmd` shim first and determine where it is pointing, then create a shim at that target.