### PR TITLE
Fixes bolt upgrade with multiple depTypes

### DIFF
--- a/src/Package.js
+++ b/src/Package.js
@@ -114,7 +114,7 @@ export default class Package {
     });
   }
 
-  getDependencyTypes(depName: string) {
+  getDependencyTypes(depName: string): Array<string> {
     let matchedTypes = [];
     for (let depType of DEPENDENCY_TYPES) {
       let deps = this.config.getDeps(depType);

--- a/src/functions/updateWorkspaceDependencies.js
+++ b/src/functions/updateWorkspaceDependencies.js
@@ -33,13 +33,15 @@ export default async function updateWorkspaceDependencies(
     let name = workspace.pkg.config.getName();
     for (let depName in dependencyToUpgrade) {
       if (pkgDependencies.has(depName)) {
-        let depType = pkg.getDependencyTypes(depName);
+        let depTypes = pkg.getDependencyTypes(depName);
         editedPackages.add(name);
-        await pkg.setDependencyVersionRange(
-          depName,
-          depType,
-          dependencyToUpgrade[depName]
-        );
+        for (let depType of depTypes) {
+          await pkg.setDependencyVersionRange(
+            depName,
+            depType,
+            dependencyToUpgrade[depName]
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes bug where packages with a dep and a devDep on a package would not be able to upgrade that dep

This *should* have been caught by flow, but wasn't because of the issue we are seeing with the type inference.

I looked at adding a test for this, but it's a pain because of how the upgrade tests are set up (my bad). There's already a refactor going on in that area, so happy to wait till after that.