### PR TITLE
Fixes bolt install to use local yarn instead of global

### DIFF
--- a/src/commands/__tests__/install.test.js
+++ b/src/commands/__tests__/install.test.js
@@ -7,7 +7,6 @@ import * as fs from '../../utils/fs';
 import Project from '../../Project';
 import Package from '../../Package';
 import fixtures from 'fixturez';
-import * as constants from '../../constants';
 
 const f = fixtures(__dirname);
 
@@ -18,7 +17,6 @@ jest.unmock('../install');
 
 const unsafeProcesses: any & typeof processes = processes;
 const unsafeYarn: any & typeof yarn = yarn;
-const unsafeConstants: any & typeof constants = constants;
 const unsafeProcess: any & typeof process = process;
 
 async function assertNodeModulesExists(pkg: Package) {
@@ -38,52 +36,40 @@ async function assertDependenciesSymlinked(pkg: Package) {
 }
 
 describe('install', () => {
-  let yarnUserAgent = 'yarn/7.7.7 npm/? node/v8.9.4 darwin x64';
-  let boltUserAgent = 'bolt/9.9.9 yarn/7.7.7 npm/? node/v8.9.4 darwin x64';
-
-  beforeEach(() => {
-    unsafeProcess.env = { parent_env: 1 };
-    unsafeYarn.userAgent.mockReturnValueOnce(yarnUserAgent);
-    unsafeConstants.BOLT_VERSION = '9.9.9';
-  });
-
   test('simple-package, should run yarn install at the root', async () => {
     let cwd = f.find('simple-package');
-    await install(toInstallOptions([], { cwd }));
-    expect(unsafeProcesses.spawn).toHaveBeenCalledTimes(1);
-    expect(unsafeProcesses.spawn).toHaveBeenCalledWith('yarn', ['install'], {
-      cwd,
-      env: { parent_env: 1, npm_config_user_agent: boltUserAgent },
-      tty: true
-    });
+    await install(
+      toInstallOptions([], {
+        cwd
+      })
+    );
+    expect(yarn.install).toHaveBeenCalledTimes(1);
+    expect(yarn.install).toHaveBeenCalledWith(cwd, false);
   });
 
   test('should still run yarn install at the root when called from ws', async () => {
     let rootDir = f.find('simple-project');
     let cwd = path.join(path.join(rootDir, 'packages', 'foo'));
-    await install(toInstallOptions([], { cwd }));
-    expect(unsafeProcesses.spawn).toHaveBeenCalledTimes(1);
-    expect(unsafeProcesses.spawn).toHaveBeenCalledWith('yarn', ['install'], {
-      cwd: rootDir,
-      env: { parent_env: 1, npm_config_user_agent: boltUserAgent },
-      tty: true
-    });
+    await install(
+      toInstallOptions([], {
+        cwd
+      })
+    );
+    expect(yarn.install).toHaveBeenCalledTimes(1);
+    expect(yarn.install).toHaveBeenCalledWith(rootDir, false);
   });
 
   test('should pass the --pure-lockfile flag correctly', async () => {
     let rootDir = f.find('simple-project');
     let cwd = path.join(path.join(rootDir, 'packages', 'foo'));
-    await install(toInstallOptions([], { cwd, pureLockfile: true }));
-    expect(unsafeProcesses.spawn).toHaveBeenCalledTimes(1);
-    expect(unsafeProcesses.spawn).toHaveBeenCalledWith(
-      'yarn',
-      ['install', '--pure-lockfile'],
-      {
-        cwd: rootDir,
-        env: { parent_env: 1, npm_config_user_agent: boltUserAgent },
-        tty: true
-      }
+    await install(
+      toInstallOptions([], {
+        cwd,
+        pureLockfile: true
+      })
     );
+    expect(yarn.install).toHaveBeenCalledTimes(1);
+    expect(yarn.install).toHaveBeenCalledWith(rootDir, true);
   });
 
   test('should work in project with scoped packages', async () => {
@@ -91,7 +77,11 @@ describe('install', () => {
     let project = await Project.init(cwd);
     let packages = await project.getPackages();
 
-    await install(toInstallOptions([], { cwd }));
+    await install(
+      toInstallOptions([], {
+        cwd
+      })
+    );
 
     for (let pkg of packages) {
       assertNodeModulesExists(pkg);
@@ -99,32 +89,16 @@ describe('install', () => {
     }
   });
 
-  test('should append the bolt version to yarns npm_config_user_agent string', async () => {
-    let spawnSpy = jest.spyOn(processes, 'spawn');
-    let cwd = f.find('nested-workspaces-with-scoped-package-names');
-
-    await install(toInstallOptions([], { cwd }));
-
-    expect(spawnSpy.mock.calls[0][2].env.npm_config_user_agent).toEqual(
-      'bolt/9.9.9 yarn/7.7.7 npm/? node/v8.9.4 darwin x64'
-    );
-  });
-
-  test('should pass existing environment variables to yarn during install', async () => {
-    let spawnSpy = jest.spyOn(processes, 'spawn');
-    let cwd = f.find('nested-workspaces-with-scoped-package-names');
-
-    await install(toInstallOptions([], { cwd }));
-
-    expect(spawnSpy.mock.calls[0][2].env.parent_env).toEqual(1);
-  });
-
   test('should run preinstall, postinstall and prepublish in each ws', async () => {
     let cwd = f.find('simple-project');
     let project = await Project.init(cwd);
     let packages = await project.getPackages();
 
-    await install(toInstallOptions([], { cwd }));
+    await install(
+      toInstallOptions([], {
+        cwd
+      })
+    );
 
     for (let pkg of packages) {
       let runFn = unsafeYarn.runIfExists;
@@ -140,7 +114,11 @@ describe('install', () => {
     let project = await Project.init(cwd);
     let packages = await project.getPackages();
 
-    await install(toInstallOptions([], { cwd }));
+    await install(
+      toInstallOptions([], {
+        cwd
+      })
+    );
 
     for (let pkg of packages) {
       assertNodeModulesExists(pkg);
@@ -153,8 +131,12 @@ describe('install', () => {
     let cwd = f.copy('invalid-project-root-dependency-on-ws');
     let project = await Project.init(cwd);
 
-    await expect(install(toInstallOptions([], { cwd }))).rejects.toBeInstanceOf(
-      Error
-    );
+    await expect(
+      install(
+        toInstallOptions([], {
+          cwd
+        })
+      )
+    ).rejects.toBeInstanceOf(Error);
   });
 });

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -32,9 +32,6 @@ export async function install(opts: InstallOptions) {
   let cwd = opts.cwd || process.cwd();
   let project = await Project.init(cwd);
   let packages = await project.getPackages();
-  let installFlags = [];
-
-  if (opts.pureLockfile) installFlags.push('--pure-lockfile');
 
   logger.info(messages.validatingProject(), { emoji: '🔎', prefix: false });
 
@@ -48,14 +45,7 @@ export async function install(opts: InstallOptions) {
     prefix: false
   });
 
-  let yarnUserAgent = await yarn.userAgent();
-  let boltUserAgent = `bolt/${BOLT_VERSION} ${yarnUserAgent}`;
-
-  await processes.spawn('yarn', ['install', ...installFlags], {
-    cwd: project.pkg.dir,
-    tty: true,
-    env: { ...process.env, npm_config_user_agent: boltUserAgent }
-  });
+  yarn.install(project.pkg.dir, opts.pureLockfile);
 
   logger.info(messages.linkingWorkspaceDependencies(), {
     emoji: '🔗',

--- a/src/utils/processes.js
+++ b/src/utils/processes.js
@@ -5,6 +5,7 @@ import type Package from '../Package';
 import type Project from '../Project';
 import pLimit from 'p-limit';
 import os from 'os';
+import path from 'path';
 
 const limit = pLimit(os.cpus().length);
 const processes = new Set();
@@ -39,6 +40,7 @@ export type SpawnOptions = {
   pkg?: Package,
   silent?: boolean,
   tty?: boolean,
+  useBasename?: boolean,
   env?: { [key: string]: ?string }
 };
 
@@ -53,8 +55,9 @@ export function spawn(
         let stdoutBuf = Buffer.from('');
         let stderrBuf = Buffer.from('');
         let isTTY = process.stdout.isTTY && opts.tty;
+        let cmdDisplayName = opts.useBasename ? path.basename(cmd) : cmd;
 
-        let cmdStr = cmd + ' ' + args.join(' ');
+        let cmdStr = cmdDisplayName + ' ' + args.join(' ');
 
         let spawnOpts: child_process$spawnOpts = {
           cwd: opts.cwd,


### PR DESCRIPTION
Turns our we never actually made bolt install use the local one at all.

Change was quite simple, tests were a pain to refactor, but I think they are a lot cleaner now.

I also fixed the issue with the long paths being shows in the logs by adding a 'useBasename' flag to spawn and turning that on for `yarn install`, and all `yarn run` commands.

I couldnt properly test that locally for some reason, `bolt install` for example wouldnt show the command in the front of the logs. But it should be safe to test in CI either way.