### PR TITLE
chore: bump yarn to v1.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "task-graph-runner": "^1.0.1",
     "temp-write": "^3.4.0",
     "typeable-promisify": "^2.0.1",
-    "yarn": "^1.6.0"
+    "yarn": "^1.9.4"
   },
   "jest": {
     "resetMocks": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3856,6 +3856,6 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-yarn@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.6.0.tgz#9cec6f7986dc237d39ec705ce74d95155fe55d4b"
+yarn@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.9.4.tgz#3b82d8446b652775723900b470d966861976924b"


### PR DESCRIPTION
What it says on the tin - bumps yarn to latest v1.9.4