### PR TITLE
add --serial and --parallel options

### DIFF
--- a/src/__tests__/Project.test.js
+++ b/src/__tests__/Project.test.js
@@ -260,7 +260,7 @@ describe('Project', () => {
     let project = await Project.init(f.find('simple-project'));
     let packages = await project.getPackages();
     let spy = jest.fn(() => Promise.resolve());
-    await project.runPackageTasks(packages, spy);
+    await project.runPackageTasks(packages, {}, spy);
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy.mock.calls[0][0]).toBeInstanceOf(Package);
   });
@@ -269,7 +269,7 @@ describe('Project', () => {
     let project = await Project.init(f.find('simple-project'));
     let packages = await project.getPackages();
     let spy = jest.fn(() => Promise.resolve());
-    await project.runPackageTasks(packages, spy);
+    await project.runPackageTasks(packages, {}, spy);
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy.mock.calls[0][0]).toBeInstanceOf(Package);
   });
@@ -280,7 +280,7 @@ describe('Project', () => {
     let packages = await project.getPackages();
     let ops = [];
 
-    await project.runPackageTasks(packages, async pkg => {
+    await project.runPackageTasks(packages, {}, async pkg => {
       ops.push('start:' + pkg.config.getName());
       // wait until next tick
       await Promise.resolve();
@@ -296,7 +296,7 @@ describe('Project', () => {
     let packages = await project.getPackages();
     let ops = [];
 
-    await project.runPackageTasks(packages, async pkg => {
+    await project.runPackageTasks(packages, {}, async pkg => {
       ops.push('start:' + pkg.getName());
       // wait until next tick
       await Promise.resolve();
@@ -312,7 +312,7 @@ describe('Project', () => {
     let packages = await project.getPackages();
     let ops = [];
 
-    await project.runPackageTasks(packages, async pkg => {
+    await project.runPackageTasks(packages, {}, async pkg => {
       ops.push('start:' + pkg.getName());
       // wait until next tick
       await Promise.resolve();
@@ -321,5 +321,41 @@ describe('Project', () => {
 
     expect(ops).toEqual(['start:bar', 'end:bar', 'start:foo', 'end:foo']);
     expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('runPackageTasks() orderMode: parallel', async () => {
+    let project = await Project.init(f.find('simple-project'));
+    let packages = await project.getPackages();
+    let ops = [];
+
+    await project.runPackageTasks(
+      packages,
+      { orderMode: 'parallel' },
+      async pkg => {
+        ops.push('start:' + pkg.getName());
+        await Promise.resolve();
+        ops.push('end:' + pkg.getName());
+      }
+    );
+
+    expect(ops).toEqual(['start:bar', 'start:foo', 'end:bar', 'end:foo']);
+  });
+
+  test('runPackageTasks() orderMode: serial', async () => {
+    let project = await Project.init(f.find('independent-workspaces'));
+    let packages = await project.getPackages();
+    let ops = [];
+
+    await project.runPackageTasks(
+      packages,
+      { orderMode: 'serial' },
+      async pkg => {
+        ops.push('start:' + pkg.getName());
+        await Promise.resolve();
+        ops.push('end:' + pkg.getName());
+      }
+    );
+
+    expect(ops).toEqual(['start:bar', 'end:bar', 'start:foo', 'end:foo']);
   });
 });

--- a/src/commands/project/remove.js
+++ b/src/commands/project/remove.js
@@ -2,12 +2,14 @@
 import Project from '../../Project';
 import Package from '../../Package';
 import * as options from '../../utils/options';
+import { type SpawnOpts } from '../../types';
 import * as logger from '../../utils/logger';
 import removeDependenciesFromPackages from '../../utils/removeDependenciesFromPackages';
 
 export type ProjectRemoveOptions = {|
   cwd?: string,
-  deps: Array<string>
+  deps: Array<string>,
+  spawnOpts: SpawnOpts
 |};
 
 export function toProjectRemoveOptions(
@@ -16,7 +18,8 @@ export function toProjectRemoveOptions(
 ): ProjectRemoveOptions {
   return {
     cwd: options.string(flags.cwd, 'cwd'),
-    deps: args
+    deps: args,
+    spawnOpts: options.toSpawnOpts(flags)
   };
 }
 
@@ -29,6 +32,7 @@ export async function projectRemove(opts: ProjectRemoveOptions) {
     project,
     packages,
     [project.pkg],
-    opts.deps
+    opts.deps,
+    opts.spawnOpts
   );
 }

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -4,10 +4,12 @@ import Package from '../Package';
 import * as options from '../utils/options';
 import * as logger from '../utils/logger';
 import removeDependenciesFromPackages from '../utils/removeDependenciesFromPackages';
+import type { SpawnOpts } from '../types';
 
 export type RemoveOptions = {|
   cwd?: string,
-  deps: Array<string>
+  deps: Array<string>,
+  spawnOpts: SpawnOpts
 |};
 
 export function toRemoveOptions(
@@ -16,7 +18,8 @@ export function toRemoveOptions(
 ): RemoveOptions {
   return {
     cwd: options.string(flags.cwd, 'cwd'),
-    deps: args
+    deps: args,
+    spawnOpts: options.toSpawnOpts(flags)
   };
 }
 
@@ -25,5 +28,11 @@ export async function remove(opts: RemoveOptions) {
   let project = await Project.init(cwd);
   let packages = await project.getPackages();
   let pkg = await Package.closest(cwd);
-  await removeDependenciesFromPackages(project, packages, [pkg], opts.deps);
+  await removeDependenciesFromPackages(
+    project,
+    packages,
+    [pkg],
+    opts.deps,
+    opts.spawnOpts
+  );
 }

--- a/src/commands/workspace/remove.js
+++ b/src/commands/workspace/remove.js
@@ -5,11 +5,13 @@ import * as options from '../../utils/options';
 import * as logger from '../../utils/logger';
 import removeDependenciesFromPackages from '../../utils/removeDependenciesFromPackages';
 import { BoltError } from '../../utils/errors';
+import type { SpawnOpts } from '../../types';
 
 export type WorkspaceRemoveOptions = {
   cwd?: string,
   pkgName: string,
-  deps: Array<string>
+  deps: Array<string>,
+  spawnOpts: SpawnOpts
 };
 
 export function toWorkspaceRemoveOptions(
@@ -20,7 +22,8 @@ export function toWorkspaceRemoveOptions(
   return {
     cwd: options.string(flags.cwd, 'cwd'),
     pkgName,
-    deps
+    deps,
+    spawnOpts: options.toSpawnOpts(flags)
   };
 }
 
@@ -36,5 +39,11 @@ export async function workspaceRemove(opts: WorkspaceRemoveOptions) {
     );
   }
 
-  await removeDependenciesFromPackages(project, packages, [pkg], opts.deps);
+  await removeDependenciesFromPackages(
+    project,
+    packages,
+    [pkg],
+    opts.deps,
+    opts.spawnOpts
+  );
 }

--- a/src/commands/workspaces/exec.js
+++ b/src/commands/workspaces/exec.js
@@ -1,5 +1,5 @@
 // @flow
-import type { FilterOpts } from '../../types';
+import type { FilterOpts, SpawnOpts } from '../../types';
 import Project from '../../Project';
 import * as options from '../../utils/options';
 import execCommand from '../../utils/execCommand';
@@ -8,6 +8,7 @@ export type WorkspacesExecOptions = {|
   cwd?: string,
   command: string,
   commandArgs: options.Args,
+  spawnOpts: SpawnOpts,
   filterOpts: FilterOpts
 |};
 
@@ -20,6 +21,7 @@ export function toWorkspacesExecOptions(
     cwd: options.string(flags.cwd, 'cwd'),
     command,
     commandArgs,
+    spawnOpts: options.toSpawnOpts(flags),
     filterOpts: options.toFilterOpts(flags)
   };
 }
@@ -30,7 +32,7 @@ export async function workspacesExec(opts: WorkspacesExecOptions) {
   let packages = await project.getPackages();
   let filteredPackages = project.filterPackages(packages, opts.filterOpts);
 
-  await project.runPackageTasks(filteredPackages, async pkg => {
+  await project.runPackageTasks(filteredPackages, opts.spawnOpts, async pkg => {
     await execCommand(project, pkg, opts.command, opts.commandArgs);
   });
 }

--- a/src/commands/workspaces/remove.js
+++ b/src/commands/workspaces/remove.js
@@ -1,5 +1,5 @@
 // @flow
-import type { FilterOpts } from '../../types';
+import type { SpawnOpts, FilterOpts } from '../../types';
 import * as options from '../../utils/options';
 import Project from '../../Project';
 import removeDependenciesFromPackages from '../../utils/removeDependenciesFromPackages';
@@ -7,6 +7,7 @@ import removeDependenciesFromPackages from '../../utils/removeDependenciesFromPa
 export type WorkspacesRemoveOptions = {
   cwd?: string,
   deps: Array<string>,
+  spawnOpts: SpawnOpts,
   filterOpts: FilterOpts
 };
 
@@ -17,6 +18,7 @@ export function toWorkspacesRemoveOptions(
   return {
     cwd: options.string(flags.cwd, 'cwd'),
     deps: args,
+    spawnOpts: options.toSpawnOpts(flags),
     filterOpts: options.toFilterOpts(flags)
   };
 }
@@ -31,6 +33,7 @@ export async function workspacesRemove(opts: WorkspacesRemoveOptions) {
     project,
     packages,
     filteredPackages,
-    opts.deps
+    opts.deps,
+    opts.spawnOpts
   );
 }

--- a/src/commands/workspaces/run.js
+++ b/src/commands/workspaces/run.js
@@ -1,5 +1,5 @@
 // @flow
-import type { FilterOpts } from '../../types';
+import type { SpawnOpts, FilterOpts } from '../../types';
 import * as options from '../../utils/options';
 import Project from '../../Project';
 import * as yarn from '../../utils/yarn';
@@ -8,6 +8,7 @@ export type WorkspacesRunOptions = {
   cwd?: string,
   script: string,
   scriptArgs: options.Args,
+  spawnOpts: SpawnOpts,
   filterOpts: FilterOpts
 };
 
@@ -20,6 +21,7 @@ export function toWorkspacesRunOptions(
     cwd: options.string(flags.cwd, 'cwd'),
     script,
     scriptArgs,
+    spawnOpts: options.toSpawnOpts(flags),
     filterOpts: options.toFilterOpts(flags)
   };
 }
@@ -30,7 +32,7 @@ export async function workspacesRun(opts: WorkspacesRunOptions) {
   let packages = await project.getPackages();
   let filteredPackages = project.filterPackages(packages, opts.filterOpts);
 
-  await project.runPackageTasks(filteredPackages, async pkg => {
+  await project.runPackageTasks(filteredPackages, opts.spawnOpts, async pkg => {
     // no need to error if script doesn't exist
     await yarn.runIfExists(pkg, opts.script, opts.scriptArgs);
   });

--- a/src/functions/runWorkspaceTasks.js
+++ b/src/functions/runWorkspaceTasks.js
@@ -1,6 +1,6 @@
 // @flow
 import Project from '../Project';
-import type { JSONValue } from '../types';
+import type { JSONValue, SpawnOpts } from '../types';
 
 type WorkspaceInfo = {
   dir: string,
@@ -10,7 +10,8 @@ type WorkspaceInfo = {
 type Task = (workspace: WorkspaceInfo) => Promise<mixed>;
 
 type Options = {
-  cwd?: string
+  cwd?: string,
+  spawnOpts?: SpawnOpts
 };
 
 export default async function runWorkspaceTasks(
@@ -18,10 +19,11 @@ export default async function runWorkspaceTasks(
   opts: Options = {}
 ): Promise<void> {
   let cwd = opts.cwd || process.cwd();
+  let spawnOpts = opts.spawnOpts || {};
   let project = await Project.init(cwd);
   let packages = await project.getPackages();
 
-  await project.runPackageTasks(packages, pkg => {
+  await project.runPackageTasks(packages, spawnOpts, pkg => {
     return task({
       dir: pkg.dir,
       config: pkg.config.json

--- a/src/types.js
+++ b/src/types.js
@@ -16,6 +16,11 @@ export type JSONValue =
   | Array<JSONValue>
   | { [key: string]: JSONValue };
 
+export type SpawnOpts = {
+  orderMode?: 'serial' | 'parallel'
+  // maxConcurrent?: number,
+};
+
 export type FilterOpts = {
   only?: string,
   ignore?: string,

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Dependency } from '../types';
+import type { Dependency, SpawnOpts, FilterOpts } from '../types';
 
 export type Args = Array<string>;
 
@@ -32,7 +32,22 @@ export function number(val: mixed, name: string): number | void {
   }
 }
 
-export function toFilterOpts(flags: Flags) {
+export function toSpawnOpts(flags: Flags): SpawnOpts {
+  let spawnOpts = {};
+
+  if (flags.parallel && flags.serial) {
+    throw new Error('Commands cannot be run both serially and in parallel');
+  }
+
+  if (flags.parallel) spawnOpts.orderMode = 'parallel';
+  if (flags.serial) spawnOpts.orderMode = 'serial';
+  // TODO:
+  // if (flags.concurrency) spawnOpts.maxConcurrent = number(flags.concurrency, 'concurrency');
+
+  return spawnOpts;
+}
+
+export function toFilterOpts(flags: Flags): FilterOpts {
   let filterOpts = {};
 
   if (flags.only) filterOpts.only = string(flags.only, 'only');

--- a/src/utils/publish.js
+++ b/src/utils/publish.js
@@ -8,10 +8,12 @@ import * as locks from './locks';
 import * as npm from './npm';
 import Project from '../Project';
 import Package from '../Package';
+import type { SpawnOpts } from '../types';
 
 export type PublishOptions = {|
   cwd?: string,
-  access?: string
+  access?: string,
+  spawnOpts?: SpawnOpts
 |};
 
 export type PackageMeta = {|
@@ -61,6 +63,7 @@ export async function publish(
   opts: PublishOptions = Object.freeze({})
 ): Promise<PackageMeta[]> {
   let cwd = opts.cwd || process.cwd();
+  let spawnOpts = opts.spawnOpts || {};
   let project = await Project.init(cwd);
   let packages = await project.getPackages();
   let publicPackages = packages.filter(pkg => !pkg.config.getPrivate());
@@ -78,7 +81,7 @@ export async function publish(
       logger.warn(messages.noUnpublishedPackagesToPublish());
     }
 
-    await project.runPackageTasks(unpublishedPackages, async pkg => {
+    await project.runPackageTasks(unpublishedPackages, spawnOpts, async pkg => {
       let name = pkg.config.getName();
       let version = pkg.config.getVersion();
       logger.info(messages.publishingPackage(name, version));

--- a/src/utils/removeDependenciesFromPackages.js
+++ b/src/utils/removeDependenciesFromPackages.js
@@ -7,6 +7,7 @@ import * as yarn from './yarn';
 import * as fs from './fs';
 import * as path from 'path';
 import { BoltError } from './errors';
+import type { SpawnOpts } from '../types';
 
 const UNINSTALL_SCRIPTS = ['preuninstall', 'uninstall', 'postuninstall'];
 
@@ -58,7 +59,8 @@ export default async function removeDependenciesFromPackages(
   project: Project,
   packages: Array<Package>,
   targetPackages: Array<Package>,
-  dependencies: Array<string>
+  dependencies: Array<string>,
+  spawnOpts: SpawnOpts
 ) {
   // Is the set of packages that we're modifying include the project package? ...
   let includesProjectPackage = false;
@@ -141,7 +143,7 @@ export default async function removeDependenciesFromPackages(
   // Run the uninstall scripts for each workspace
   await Promise.all(
     UNINSTALL_SCRIPTS.map(async script => {
-      await project.runPackageTasks(includedPackages, async pkg => {
+      await project.runPackageTasks(includedPackages, spawnOpts, async pkg => {
         await yarn.runIfExists(pkg, script);
       });
     })


### PR DESCRIPTION
A whole bunch of people have asked for these. 

**Runs as parallel as possible while respecting the dep graph:** (safest)

```sh
bolt workspaces exec -- cmd
```

**Runs as parallel as possible ignoring the dep graph:** (fastest)

```sh
bolt workspaces exec --parallel -- cmd
```

**Runs sequentially:** (slowest)

```sh
bolt workspaces exec --serial -- cmd
```

I just added this into `runPackageTasks` so anything that runs across all your packages should now support these flags.

I also want to add a `--concurrency <n>` option for setting a limit of max processes to spawn at any given time. I've set up the basis for adding that, but I wasn't sure how I wanted to do it in code yet so I left it out as a TODO.

cc @kayneb