### PR TITLE
Pass bolt_config_user_agent to env when running install

### DIFF
--- a/src/utils/__tests__/yarn.test.js
+++ b/src/utils/__tests__/yarn.test.js
@@ -101,8 +101,29 @@ describe('utils/yarn', () => {
       );
       delete process.env.TEST_CANARY;
     });
-  });
 
+    it('should add bolt_config_user_agent environment variable during install', async () => {
+      const cwd = 'a/fake/path';
+      unsafeConstants.BOLT_VERSION = '9.9.9';
+      const yarnUserAgent = 'yarn/7.7.7 npm/? node/v8.9.4 darwin x64';
+      const boltUserAgent =
+      'bolt/9.9.9 yarn/7.7.7 npm/? node/v8.9.4 darwin x64';
+      const localYarn = await getLocalYarnPath();
+      unsafeProcesses.spawn.mockReturnValueOnce(
+        Promise.resolve({ stdout: yarnUserAgent })
+      );
+
+      await yarn.install(cwd);
+      expect(unsafeProcesses.spawn).toHaveBeenCalledWith(
+        localYarn,
+        ['install'],
+        containDeep({
+          env: { bolt_config_user_agent: boltUserAgent }
+        })
+      );
+    });
+  });
+  
   describe('add()', () => {
     let cwd;
     let project;

--- a/src/utils/yarn.js
+++ b/src/utils/yarn.js
@@ -34,7 +34,7 @@ export async function install(cwd: string, pureLockfile?: boolean) {
   await processes.spawn(localYarn, ['install', ...installFlags], {
     cwd,
     tty: true,
-    env: { ...process.env, npm_config_user_agent: boltUserAgent },
+    env: { ...process.env, npm_config_user_agent: boltUserAgent, bolt_config_user_agent: boltUserAgent },
     useBasename: true
   });
 }


### PR DESCRIPTION
`npm_config_user_agent` seems being overridden by `yarn`.
This PR exposes bolt version via environment variable.