### PR TITLE
Fix failure to spawn yarn in case the path contains spaces

### DIFF
--- a/src/utils/yarn.js
+++ b/src/utils/yarn.js
@@ -31,7 +31,7 @@ export async function install(cwd: string, pureLockfile?: boolean) {
   let yarnUserAgent = await userAgent();
   let boltUserAgent = `bolt/${BOLT_VERSION} ${yarnUserAgent}`;
 
-  await processes.spawn(localYarn, ['install', ...installFlags], {
+  await processes.spawn(`"${localYarn}"`, ['install', ...installFlags], {
     cwd,
     tty: true,
     env: { ...process.env, npm_config_user_agent: boltUserAgent, bolt_config_user_agent: boltUserAgent },


### PR DESCRIPTION
If localYarn path contains spaces, it fails to be spawned. The path needs to be wrapped in double quotes. 
Especially common on Windows with `C\Users\FirstName LastName\...\yarn`