### PR TITLE
Fix project run throwing invalid error

### DIFF
--- a/src/commands/project/run.js
+++ b/src/commands/project/run.js
@@ -2,6 +2,7 @@
 import Project from '../../Project';
 import * as options from '../../utils/options';
 import * as yarn from '../../utils/yarn';
+import * as logger from '../../utils/logger';
 import { BoltError } from '../../utils/errors';
 
 export type ProjectRunOptions = {
@@ -25,9 +26,12 @@ export function toProjectRunOptions(
 export async function projectRun(opts: ProjectRunOptions) {
   let cwd = opts.cwd || process.cwd();
   let project = await Project.init(cwd);
-  let validScript = await yarn.run(project.pkg, opts.script, opts.scriptArgs);
+  let script = await yarn.getScript(project.pkg, opts.script);
 
-  if (!validScript) {
+  if (script) {
+    logger.cmd(script, opts.scriptArgs);
+    await yarn.run(project.pkg, opts.script, opts.scriptArgs);
+  } else {
     throw new BoltError(
       `Package at "${project.pkg
         .dir}" does not have a script named "${opts.script}"`


### PR DESCRIPTION
Fixes #209.

I updated project/run.js to behave the same as run.js. No tests exist at this stage for `bolt run` or `bolt project run`, I can look into adding them if required.