### PR TITLE
Proposal fix for Issue #207

### DIFF
--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -57,10 +57,15 @@ function stripExtension(filePath: string) {
 }
 
 async function cmdShim(src: string, dest: string) {
-  const currentShimTarget = path.resolve(
-    path.dirname(src),
-    await readCmdShim(src)
-  );
+  var currentShimTarget = src;
+  try{
+    var currentShimTarget = path.resolve(
+      path.dirname(src),
+      await readCmdShim(src)
+    );
+  }catch(err){
+    
+  }
   await promisify(cb => _cmdShim(currentShimTarget, stripExtension(dest), cb));
 }
 


### PR DESCRIPTION
Recently i have encountered the same issues as #207 . It looks like packages in the workspaces referencing another package in the same workspace dont have a shim create thats why `readCmdShim` fails, because it expects a shim file. 
My solution just uses the `src` variable to create the new shim file after that if there occurs another reference to that package it will read the shim file and use that path.