### PR TITLE
Make all filter opts arrays

### DIFF
--- a/src/__tests__/Project.test.js
+++ b/src/__tests__/Project.test.js
@@ -161,7 +161,7 @@ describe('Project', () => {
     let project = await Project.init(f.find('nested-workspaces'));
     let packages = await project.getPackages();
     let filtered = await project.filterPackages(packages, {
-      only: 'foo'
+      only: ['foo']
     });
     assertPackages(filtered, ['foo']);
   });
@@ -170,7 +170,7 @@ describe('Project', () => {
     let project = await Project.init(f.find('nested-workspaces'));
     let packages = await project.getPackages();
     let filtered = await project.filterPackages(packages, {
-      only: 'ba*'
+      only: ['ba*']
     });
     assertPackages(filtered, ['bar', 'baz']);
   });
@@ -179,7 +179,7 @@ describe('Project', () => {
     let project = await Project.init(f.find('nested-workspaces'));
     let packages = await project.getPackages();
     let filtered = await project.filterPackages(packages, {
-      ignore: 'bar'
+      ignore: ['bar']
     });
     assertPackages(filtered, ['foo', 'baz']);
   });
@@ -188,8 +188,8 @@ describe('Project', () => {
     let project = await Project.init(f.find('nested-workspaces'));
     let packages = await project.getPackages();
     let filtered = await project.filterPackages(packages, {
-      only: 'ba*',
-      ignore: 'bar'
+      only: ['ba*'],
+      ignore: ['bar']
     });
     assertPackages(filtered, ['baz']);
   });
@@ -198,7 +198,7 @@ describe('Project', () => {
     let project = await Project.init(f.find('nested-workspaces'));
     let packages = await project.getPackages();
     let filtered = await project.filterPackages(packages, {
-      onlyFs: 'packages/foo'
+      onlyFs: ['packages/foo']
     });
     assertPackages(filtered, ['foo']);
   });
@@ -207,7 +207,7 @@ describe('Project', () => {
     let project = await Project.init(f.find('nested-workspaces'));
     let packages = await project.getPackages();
     let filtered = await project.filterPackages(packages, {
-      ignoreFs: 'packages/foo'
+      ignoreFs: ['packages/foo']
     });
     assertPackages(filtered, ['bar', 'baz']);
   });
@@ -216,8 +216,8 @@ describe('Project', () => {
     let project = await Project.init(f.find('nested-workspaces'));
     let packages = await project.getPackages();
     let filtered = await project.filterPackages(packages, {
-      onlyFs: '**/packages/ba*',
-      ignoreFs: '**/bar'
+      onlyFs: ['**/packages/ba*'],
+      ignoreFs: ['**/bar']
     });
     assertPackages(filtered, ['baz']);
   });
@@ -226,8 +226,8 @@ describe('Project', () => {
     let project = await Project.init(f.find('nested-workspaces'));
     let packages = await project.getPackages();
     let filtered = await project.filterPackages(packages, {
-      only: 'ba*',
-      ignoreFs: '**/bar'
+      only: ['ba*'],
+      ignoreFs: ['**/bar']
     });
     assertPackages(filtered, ['baz']);
   });
@@ -240,22 +240,22 @@ describe('Project', () => {
 
     assertPackages(
       await project.filterPackages(packages, {
-        only: '**/foo'
+        only: ['**/foo']
       }),
       ['@scope/foo']
     );
 
     assertPackages(
       await project.filterPackages(packages, {
-        ignore: '**/foo'
+        ignore: ['**/foo']
       }),
       ['@scope/bar', '@scope/baz']
     );
 
     assertPackages(
       await project.filterPackages(packages, {
-        onlyFs: '**/packages/ba*',
-        ignore: '@scope/baz'
+        onlyFs: ['**/packages/ba*'],
+        ignore: ['@scope/baz']
       }),
       ['@scope/bar']
     );

--- a/src/cli.js
+++ b/src/cli.js
@@ -425,7 +425,7 @@ export default async function cli(argv: Array<string>, exit: boolean = false) {
   processes.handleSignals();
 
   try {
-    await runCommandFromCli(input, flags);
+    await runCommandFromCli(input, (flags: any));
   } catch (err) {
     if (err instanceof BoltError) {
       logger.error(err.message);

--- a/src/functions/getWorkspaces.js
+++ b/src/functions/getWorkspaces.js
@@ -24,7 +24,7 @@ export default async function getWorkspaces(
   let project = await Project.init(cwd);
   let packages = await project.getPackages();
 
-  let filtered = project.filterPackages(packages, toFilterOpts({
+  let filtered = project.filterPackages(packages, options.toFilterOpts({
     only: opts.only,
     ignore: opts.ignore,
     onlyFs: opts.onlyFs,

--- a/src/functions/getWorkspaces.js
+++ b/src/functions/getWorkspaces.js
@@ -1,13 +1,14 @@
 // @flow
 import Project from '../Project';
 import type { JSONValue } from '../types';
+import * as options from '../utils/options';
 
 type Options = {
   cwd?: string,
-  only?: string,
-  ignore?: string,
-  onlyFs?: string,
-  ignoreFs?: string
+  only?: Array<string> | string,
+  ignore?: Array<string> | string,
+  onlyFs?: Array<string> | string,
+  ignoreFs?: Array<string> | string
 };
 
 type Packages = Array<{
@@ -23,12 +24,12 @@ export default async function getWorkspaces(
   let project = await Project.init(cwd);
   let packages = await project.getPackages();
 
-  let filtered = project.filterPackages(packages, {
+  let filtered = project.filterPackages(packages, toFilterOpts({
     only: opts.only,
     ignore: opts.ignore,
     onlyFs: opts.onlyFs,
     ignoreFs: opts.ignoreFs
-  });
+  }));
 
   return filtered.map(pkg => ({
     dir: pkg.dir,

--- a/src/types.js
+++ b/src/types.js
@@ -22,10 +22,10 @@ export type SpawnOpts = {
 };
 
 export type FilterOpts = {
-  only?: string,
-  ignore?: string,
-  onlyFs?: string,
-  ignoreFs?: string
+  only?: Array<string>,
+  ignore?: Array<string>,
+  onlyFs?: Array<string>,
+  ignoreFs?: Array<string>
 };
 
 export type Dependency = {

--- a/src/utils/__tests__/options.test.js
+++ b/src/utils/__tests__/options.test.js
@@ -29,11 +29,11 @@ describe('options', () => {
   });
 
   test('toFilerOptions', () => {
-    expect(toFilterOpts({ only: 'only' })).toEqual({ only: 'only' });
-    expect(toFilterOpts({ onlyFs: 'onlyFs' })).toEqual({ onlyFs: 'onlyFs' });
-    expect(toFilterOpts({ ignore: 'ignore' })).toEqual({ ignore: 'ignore' });
+    expect(toFilterOpts({ only: 'only' })).toEqual({ only: ['only'] });
+    expect(toFilterOpts({ onlyFs: 'onlyFs' })).toEqual({ onlyFs: ['onlyFs'] });
+    expect(toFilterOpts({ ignore: 'ignore' })).toEqual({ ignore: ['ignore'] });
     expect(toFilterOpts({ ignoreFs: 'ignoreFs' })).toEqual({
-      ignoreFs: 'ignoreFs'
+      ignoreFs: ['ignoreFs']
     });
     expect(toFilterOpts({})).toEqual({});
   });

--- a/src/utils/__tests__/options.test.js
+++ b/src/utils/__tests__/options.test.js
@@ -28,12 +28,42 @@ describe('options', () => {
     expect(() => number('number', 'flag')).toThrow();
   });
 
-  test('toFilerOptions', () => {
-    expect(toFilterOpts({ only: 'only' })).toEqual({ only: ['only'] });
-    expect(toFilterOpts({ onlyFs: 'onlyFs' })).toEqual({ onlyFs: ['onlyFs'] });
-    expect(toFilterOpts({ ignore: 'ignore' })).toEqual({ ignore: ['ignore'] });
-    expect(toFilterOpts({ ignoreFs: 'ignoreFs' })).toEqual({
-      ignoreFs: ['ignoreFs']
+  test('toFilterOptions', () => {
+    expect(toFilterOpts({ only: 'one' })).toEqual({
+      only: ['one']
+    });
+    expect(toFilterOpts({ only: 'one,two' })).toEqual({
+      only: ['one', 'two']
+    });
+    expect(toFilterOpts({ only: ['one', 'two'] })).toEqual({
+      only: ['one', 'two']
+    });
+    expect(toFilterOpts({ onlyFs: 'one' })).toEqual({
+      onlyFs: ['one']
+    });
+    expect(toFilterOpts({ onlyFs: 'one,two' })).toEqual({
+      onlyFs: ['one', 'two']
+    });
+    expect(toFilterOpts({ onlyFs: ['one', 'two'] })).toEqual({
+      onlyFs: ['one', 'two']
+    });
+    expect(toFilterOpts({ ignore: 'one' })).toEqual({
+      ignore: ['one']
+    });
+    expect(toFilterOpts({ ignore: 'one,two' })).toEqual({
+      ignore: ['one', 'two']
+    });
+    expect(toFilterOpts({ ignore: ['one', 'two'] })).toEqual({
+      ignore: ['one', 'two']
+    });
+    expect(toFilterOpts({ ignoreFs: 'one' })).toEqual({
+      ignoreFs: ['one']
+    });
+    expect(toFilterOpts({ ignoreFs: 'one,two' })).toEqual({
+      ignoreFs: ['one', 'two']
+    });
+    expect(toFilterOpts({ ignoreFs: ['one', 'two'] })).toEqual({
+      ignoreFs: ['one', 'two']
     });
     expect(toFilterOpts({})).toEqual({});
   });

--- a/src/utils/globs.js
+++ b/src/utils/globs.js
@@ -21,10 +21,11 @@ export function findWorkspaces(cwd: string, patterns: Array<string>) {
 
 export function matchOnlyAndIgnore(
   paths: Array<string>,
-  only: string | void,
-  ignore: string | void
+  only: Array<string> = ['**'],
+  ignore: Array<string> = []
 ) {
-  let onlyPattern = only || '**';
-  let ignorePattern = ignore ? `!${ignore}` : '';
-  return matchGlobs(paths, [onlyPattern, ignorePattern]);
+  return matchGlobs(paths, [
+    ...only,
+    ...ignore.map(pattern => `!${pattern}`),
+  ]);
 }

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -5,7 +5,7 @@ export type Args = Array<string>;
 
 export type Flags = {
   '--'?: Array<string>,
-  [key: string]: boolean | string | Array<string>
+  [key: string]: boolean | string | Array<string> | void
 };
 
 export function string(val: mixed, name: string): string | void {

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -5,7 +5,7 @@ export type Args = Array<string>;
 
 export type Flags = {
   '--'?: Array<string>,
-  [key: string]: boolean | string
+  [key: string]: boolean | string | Array<string>
 };
 
 export function string(val: mixed, name: string): string | void {
@@ -32,6 +32,22 @@ export function number(val: mixed, name: string): number | void {
   }
 }
 
+function isArrayOfStrings(val: mixed) {
+  return Array.isArray(val) && val.every(v => typeof v === 'string');
+}
+
+export function arrayify(val: mixed, name: string): Array<string> {
+  if (typeof val === 'undefined') {
+    return [];
+  } else if (typeof val === 'string') {
+    return val.split(',');
+  } else if (Array.isArray(val) && val.every(v => typeof v === 'string')) {
+    return ((val: any): Array<string>);
+  } else {
+    throw new Error(`Flag "${name}" must be string or an array of strings`);
+  }
+}
+
 export function toSpawnOpts(flags: Flags): SpawnOpts {
   let spawnOpts = {};
 
@@ -51,10 +67,10 @@ export function toSpawnOpts(flags: Flags): SpawnOpts {
 export function toFilterOpts(flags: Flags): FilterOpts {
   let filterOpts = {};
 
-  if (flags.only) filterOpts.only = string(flags.only, 'only');
-  if (flags.onlyFs) filterOpts.onlyFs = string(flags.onlyFs, 'onlyFs');
-  if (flags.ignore) filterOpts.ignore = string(flags.ignore, 'ignore');
-  if (flags.ignoreFs) filterOpts.ignoreFs = string(flags.ignoreFs, 'ignoreFs');
+  if (flags.only) filterOpts.only = arrayify(flags.only, 'only');
+  if (flags.onlyFs) filterOpts.onlyFs = arrayify(flags.onlyFs, 'onlyFs');
+  if (flags.ignore) filterOpts.ignore = arrayify(flags.ignore, 'ignore');
+  if (flags.ignoreFs) filterOpts.ignoreFs = arrayify(flags.ignoreFs, 'ignoreFs');
 
   return filterOpts;
 }


### PR DESCRIPTION

This should now work:

```sh
bolt --ignore foo --ignore bar
```

As well as this:

```js
bolt.getWorkspaces({
  ignore: ['foo', 'bar']
})
```

While still supporting this:

```sh
bolt --ignore foo
```

And this:

```js
bolt.getWorkspaces({
  ignore: 'foo'
})
```