### PR TITLE
Add new line to the end of file, preserve line endings style

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cmd-shim": "^2.0.2",
     "cross-spawn": "^5.1.0",
     "detect-indent": "^5.0.0",
-    "detect-newline": "^3.0.0",
+    "detect-newline": "2.1.0",
     "find-up": "^2.1.0",
     "globby": "^6.1.0",
     "inquirer": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "cmd-shim": "^2.0.2",
     "cross-spawn": "^5.1.0",
     "detect-indent": "^5.0.0",
+    "detect-newline": "^3.0.0",
     "find-up": "^2.1.0",
     "globby": "^6.1.0",
     "inquirer": "3.3.0",

--- a/src/Config.js
+++ b/src/Config.js
@@ -72,6 +72,7 @@ export default class Config {
   fileContents: string;
   json: JSONValue;
   indent: string;
+  newline: string;
   invalid: boolean;
 
   constructor(filePath: string, fileContents: string) {

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,4 +1,5 @@
 // @flow
+import os from 'os';
 import pkgUp from 'pkg-up';
 import detectIndent from 'detect-indent';
 import detectNewline from 'detect-newline';
@@ -80,7 +81,7 @@ export default class Config {
     this.fileContents = fileContents;
     try {
       this.indent = detectIndent(fileContents).indent || '  ';
-      this.newline = detectNewline(fileContents) || '\n';
+      this.newline = detectNewline(fileContents) || os.EOL;
       this.json = parseJson(fileContents);
     } catch (e) {
       if (e.name === 'JSONError') {

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,6 +1,7 @@
 // @flow
 import pkgUp from 'pkg-up';
 import detectIndent from 'detect-indent';
+import detectNewline from 'detect-newline';
 import parseJson from 'parse-json';
 import type { JSONValue, DependencySet } from './types';
 import * as fs from './utils/fs';
@@ -78,6 +79,7 @@ export default class Config {
     this.fileContents = fileContents;
     try {
       this.indent = detectIndent(fileContents).indent || '  ';
+      this.newline = detectNewline(fileContents) || '\n';
       this.json = parseJson(fileContents);
     } catch (e) {
       if (e.name === 'JSONError') {
@@ -108,7 +110,9 @@ export default class Config {
   }
 
   async write(json: JSONValue) {
-    let fileContents = JSON.stringify(json, null, this.indent);
+    let fileContents =
+      JSON.stringify(json, null, this.indent).replace(/\n/g, this.newline) +
+      this.newline;
     await fs.writeFile(this.filePath, fileContents);
     this.fileContents = fileContents;
     this.json = json;
@@ -237,8 +241,9 @@ export default class Config {
     if (typeof workspaces === 'undefined') return;
     return toArrayOfStrings(
       workspaces,
-      `package.json#bolt.workspaces must be an array of globs. See "${this
-        .filePath}"`
+      `package.json#bolt.workspaces must be an array of globs. See "${
+        this.filePath
+      }"`
     );
   }
 
@@ -248,8 +253,9 @@ export default class Config {
     if (typeof deps === 'undefined') return;
     return toObjectOfStrings(
       deps,
-      `package.json#${depType} must be an object of strings. See "${this
-        .filePath}"`
+      `package.json#${depType} must be an object of strings. See "${
+        this.filePath
+      }"`
     );
   }
 
@@ -259,8 +265,9 @@ export default class Config {
     if (typeof scripts === 'undefined') return;
     return toObjectOfStrings(
       scripts,
-      `package.json#scripts must be an object of strings. See "${this
-        .filePath}"`
+      `package.json#scripts must be an object of strings. See "${
+        this.filePath
+      }"`
     );
   }
 
@@ -271,8 +278,9 @@ export default class Config {
     if (typeof bin === 'string') return bin;
     return toObjectOfStrings(
       bin,
-      `package.json#bin must be an object of strings or a string. See "${this
-        .filePath}"`
+      `package.json#bin must be an object of strings or a string. See "${
+        this.filePath
+      }"`
     );
   }
 }

--- a/src/__tests__/Config.test.js
+++ b/src/__tests__/Config.test.js
@@ -1,4 +1,5 @@
 // @flow
+import os from 'os';
 import Config from '../Config';
 import * as fs from '../utils/fs';
 import { mkdtempSync } from 'fs';
@@ -40,7 +41,7 @@ describe('writeConfigFile', () => {
   it('should write a json file', async () => {
     let filePath = path.join(f.find('simple-package'), 'package.json');
     let json = { name: 'wat', version: '0.0.0' };
-    let fileContents = JSON.stringify(json, null, 2) + '\n';
+    let fileContents = JSON.stringify(json, null, 2) + os.EOL;
     let config = await Config.init(filePath);
     await config.write(json);
     expect(fs.writeFile).toHaveBeenCalledWith(filePath, fileContents);
@@ -52,7 +53,7 @@ describe('writeConfigFile', () => {
       'package.json'
     );
     let json = { name: 'wat', version: '0.0.0' };
-    let fileContents = JSON.stringify(json, null, 4) + '\n';
+    let fileContents = JSON.stringify(json, null, 4) + os.EOL;
     let config = await Config.init(filePath);
     await config.write(json);
     expect(fs.writeFile).toHaveBeenCalledWith(filePath, fileContents);
@@ -64,7 +65,7 @@ describe('writeConfigFile', () => {
       'package.json'
     );
     let json = { name: 'wat', version: '0.0.0' };
-    let fileContents = JSON.stringify(json, null, 2) + '\n';
+    let fileContents = JSON.stringify(json, null, 2) + os.EOL;
     let config = await Config.init(filePath);
     await config.write(json);
     expect(fs.writeFile).toHaveBeenCalledWith(filePath, fileContents);

--- a/src/__tests__/Config.test.js
+++ b/src/__tests__/Config.test.js
@@ -3,6 +3,7 @@ import Config from '../Config';
 import * as fs from '../utils/fs';
 import { mkdtempSync } from 'fs';
 import * as path from 'path';
+import detectNewline from 'detect-newline';
 import fixtures from 'fixturez';
 
 const f = fixtures(__dirname);
@@ -39,7 +40,7 @@ describe('writeConfigFile', () => {
   it('should write a json file', async () => {
     let filePath = path.join(f.find('simple-package'), 'package.json');
     let json = { name: 'wat', version: '0.0.0' };
-    let fileContents = JSON.stringify(json, null, 2);
+    let fileContents = JSON.stringify(json, null, 2) + '\n';
     let config = await Config.init(filePath);
     await config.write(json);
     expect(fs.writeFile).toHaveBeenCalledWith(filePath, fileContents);
@@ -51,7 +52,7 @@ describe('writeConfigFile', () => {
       'package.json'
     );
     let json = { name: 'wat', version: '0.0.0' };
-    let fileContents = JSON.stringify(json, null, 4);
+    let fileContents = JSON.stringify(json, null, 4) + '\n';
     let config = await Config.init(filePath);
     await config.write(json);
     expect(fs.writeFile).toHaveBeenCalledWith(filePath, fileContents);
@@ -63,10 +64,26 @@ describe('writeConfigFile', () => {
       'package.json'
     );
     let json = { name: 'wat', version: '0.0.0' };
-    let fileContents = JSON.stringify(json, null, 2);
+    let fileContents = JSON.stringify(json, null, 2) + '\n';
     let config = await Config.init(filePath);
     await config.write(json);
     expect(fs.writeFile).toHaveBeenCalledWith(filePath, fileContents);
+  });
+
+  it('should preserve the line endings style of the source json', async () => {
+    let filePath = path.join(f.find('simple-package'), 'package.json');
+    const packageFileContent = await fs.readFile(filePath);
+    const readMock = jest.spyOn(fs, 'readFile').mockImplementation(async () => {
+      return packageFileContent.toString().replace(/\n/g, '\r\n');
+    });
+
+    let json = { name: 'wat', version: '0.0.0' };
+    let fileContents =
+      JSON.stringify(json, null, 2).replace(/\n/g, '\r\n') + '\r\n';
+    let config = await Config.init(filePath);
+    await config.write(json);
+    expect(fs.writeFile).toHaveBeenCalledWith(filePath, fileContents);
+    readMock.mockRestore();
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,10 +1413,10 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-newline@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.0.0.tgz#8ae477c089e51872c264531cd6547719c0b86b2f"
-  integrity sha512-JAP22dVPAqvhdRFFxK1G5GViIokyUn0UWXRNW0ztK96fsqi9cuM8w8ESbSk+T2w5OVorcMcL6m7yUg1RrX+2CA==
+detect-newline@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
 diff@^3.2.0:
   version "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,6 +1413,11 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
+detect-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.0.0.tgz#8ae477c089e51872c264531cd6547719c0b86b2f"
+  integrity sha512-JAP22dVPAqvhdRFFxK1G5GViIokyUn0UWXRNW0ztK96fsqi9cuM8w8ESbSk+T2w5OVorcMcL6m7yUg1RrX+2CA==
+
 diff@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"


### PR DESCRIPTION
This PR fixes a couple of issues with bolt - 

- Bolt is opinionated about the line endings style – it always uses `\n` to denote line endings. This PR enables bolt to automatically detect line endings style (`\n` vs `\r\n`) using `detect-newline` and preserve the style when updating / writing to a package.json file

- Whenever bolt writes a package.json, it now adds a newline character to the last line, in accordance with the [POSIX definition of a line](https://stackoverflow.com/a/729795/3210476).

Note that these issues have already been fixed by `npm` ([here](https://github.com/npm/npm/pull/19904)) and `yarn` ([here](https://github.com/yarnpkg/yarn/commit/05bf97728cbe92f034f7d4596830f481a65fe8fa)), and this just brings bolt's implementation on par.

## Motivation
When using prettier or an opinionated editor alongside bolt, there is a constant push and pull between these tools that leads to ghost diffs like these –

![image](https://user-images.githubusercontent.com/8946207/56498676-75ba1900-6520-11e9-9237-ab93ee1ca1bb.png)
