### PR TITLE
Get rid of yarn run -- warning

### DIFF
--- a/src/utils/yarn.js
+++ b/src/utils/yarn.js
@@ -109,7 +109,7 @@ export async function run(
   let spawnArgs = ['run', '-s', script];
 
   if (args.length) {
-    spawnArgs = spawnArgs.concat('--', args);
+    spawnArgs = spawnArgs.concat(args);
   }
   await processes.spawn(localYarnRelative, spawnArgs, {
     cwd: pkg.dir,


### PR DESCRIPTION
Fixing this warning

```
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
```