### PR TITLE
add feedback on otp failure

### DIFF
--- a/src/utils/npm.js
+++ b/src/utils/npm.js
@@ -64,7 +64,11 @@ export function publish(
       return { published: true };
     } catch (error) {
       // Publish failed
-      return { published: false };
+      const requiresOTP =
+        error.stderr.includes('one-time pass') ||
+        error.message.includes('user TTY');
+
+      return { published: false, requiresOTP };
     }
   });
 }

--- a/src/utils/publish.js
+++ b/src/utils/publish.js
@@ -90,10 +90,11 @@ export async function publish(
       let publishDir = pkg.dir;
 
       if (opts.prePublish) {
-        publishDir = await opts.prePublish({
-          name,
-          pkg,
-        }) || pkg.dir;
+        publishDir =
+          (await opts.prePublish({
+            name,
+            pkg
+          })) || pkg.dir;
       }
 
       let publishConfirmation = await npm.publish(name, {
@@ -104,7 +105,8 @@ export async function publish(
       publishedPackages.push({
         name,
         newVersion: version,
-        published: publishConfirmation && publishConfirmation.published
+        published: publishConfirmation && publishConfirmation.published,
+        requiresOTP: publishConfirmation && publishConfirmation.requiresOTP
       });
     });
 


### PR DESCRIPTION
I was looking at modifying changesets to prompt for OTP on this kind of failure, but wasn't getting enough information back from bolt. This should allow the desired change in changesets.