### PR TITLE
Fix fix for yarn setting an npm_config_registry

### DIFF
--- a/src/utils/__tests__/npm.test.js
+++ b/src/utils/__tests__/npm.test.js
@@ -50,7 +50,7 @@ describe('npm', () => {
         containDeep({
           cwd,
           env: {
-            npm_config_registry: 'https://registry.npmjs.org/'
+            npm_config_registry: undefined
           }
         })
       );

--- a/src/utils/__tests__/npm.test.js
+++ b/src/utils/__tests__/npm.test.js
@@ -11,6 +11,8 @@ const f = fixtures(__dirname);
 jest.mock('../logger');
 jest.mock('../processes');
 
+let REAL_ENV = process.env
+
 const unsafeProcesses: any & typeof processes = processes;
 
 describe('npm', () => {
@@ -20,6 +22,10 @@ describe('npm', () => {
 
     beforeEach(async () => {
       cwd = f.find('simple-project');
+    });
+
+    afterEach(async () => {
+      process.env = REAL_ENV
     });
 
     test('returns published true when npm publish <package> is successesful', async () => {
@@ -39,6 +45,7 @@ describe('npm', () => {
     });
 
     test('Overrides the npm_config_registry env variable correctly', async () => {
+      process.env = { npm_config_registry: "https://registry.yarnpkg.com" }
       unsafeProcesses.spawn.mockImplementation(() => Promise.resolve());
       result = await npm.publish('simple-project', {
         cwd
@@ -49,9 +56,7 @@ describe('npm', () => {
         ['publish'],
         containDeep({
           cwd,
-          env: {
-            npm_config_registry: undefined
-          }
+          env: {}
         })
       );
     });

--- a/src/utils/npm.js
+++ b/src/utils/npm.js
@@ -54,12 +54,14 @@ export function publish(
     try {
       // Due to a super annoying issue in yarn, we have to manually override this env variable
       // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
-      const envOverride = {
-        npm_config_registry: 'https://registry.npmjs.org/'
-      };
+      let registry = process.env === 'https://registry.yarnpkg.com'
+        ? undefined
+        : process.env.npm_config_registry
       await processes.spawn('npm', ['publish', ...publishFlags], {
         cwd: opts.cwd,
-        env: Object.assign({}, process.env, envOverride)
+        env: Object.assign({}, process.env, {
+          npm_config_registry: registry
+        })
       });
       return { published: true };
     } catch (error) {

--- a/src/utils/npm.js
+++ b/src/utils/npm.js
@@ -7,6 +7,13 @@ import pLimit from 'p-limit';
 
 const npmRequestLimit = pLimit(40);
 
+function getCorrectRegistry() {
+  let registry = process.env.npm_config_registry === 'https://registry.yarnpkg.com'
+    ? undefined
+    : process.env.npm_config_registry
+  return registry
+}
+
 export function info(pkgName: string) {
   return npmRequestLimit(async () => {
     logger.info(messages.npmInfo(pkgName));
@@ -18,7 +25,7 @@ export function info(pkgName: string) {
     // as they will always give a 404, which will tell `publish` to always try to publish.
     // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
     const envOverride = {
-      npm_config_registry: 'https://registry.npmjs.org/'
+      npm_config_registry: getCorrectRegistry()
     };
 
     let result = await processes.spawn('npm', ['info', pkgName, '--json'], {
@@ -54,14 +61,12 @@ export function publish(
     try {
       // Due to a super annoying issue in yarn, we have to manually override this env variable
       // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
-      let registry = process.env === 'https://registry.yarnpkg.com'
-        ? undefined
-        : process.env.npm_config_registry
+      const envOverride = {
+        npm_config_registry: getCorrectRegistry()
+      };
       await processes.spawn('npm', ['publish', ...publishFlags], {
         cwd: opts.cwd,
-        env: Object.assign({}, process.env, {
-          npm_config_registry: registry
-        })
+        env: Object.assign({}, process.env, envOverride)
       });
       return { published: true };
     } catch (error) {


### PR DESCRIPTION
Fixes https://github.com/boltpkg/bolt/pull/190#issuecomment-499965466

The problem with the original fix is that it makes the same mistake Yarn did by overwriting all registry configs. So I changed this to do the minimal amount of work to revert Yarn's incorrect behavior.

Note: Setting an env variable to `undefined` just completely eliminates it, which will cause npm to use its default behavior. Only when `npm_config_registry` has been set to something other than `registry.yarnpkg.com` should we respect it.