### PR TITLE
feat: allow passing --frozen-lockfile to yarn

### DIFF
--- a/src/commands/__tests__/install.test.js
+++ b/src/commands/__tests__/install.test.js
@@ -44,7 +44,7 @@ describe('install', () => {
       })
     );
     expect(yarn.install).toHaveBeenCalledTimes(1);
-    expect(yarn.install).toHaveBeenCalledWith(cwd, false);
+    expect(yarn.install).toHaveBeenCalledWith(cwd, 'default');
   });
 
   test('should still run yarn install at the root when called from ws', async () => {
@@ -56,7 +56,7 @@ describe('install', () => {
       })
     );
     expect(yarn.install).toHaveBeenCalledTimes(1);
-    expect(yarn.install).toHaveBeenCalledWith(rootDir, false);
+    expect(yarn.install).toHaveBeenCalledWith(rootDir, 'default');
   });
 
   test('should pass the --pure-lockfile flag correctly', async () => {
@@ -69,7 +69,34 @@ describe('install', () => {
       })
     );
     expect(yarn.install).toHaveBeenCalledTimes(1);
-    expect(yarn.install).toHaveBeenCalledWith(rootDir, true);
+    expect(yarn.install).toHaveBeenCalledWith(rootDir, 'pure');
+  });
+
+  test('should pass the --frozen-lockfile flag correctly', async () => {
+    const rootDir = f.find('simple-project');
+    const cwd = path.join(path.join(rootDir, 'packages', 'foo'));
+    await install(
+      toInstallOptions([], {
+        cwd,
+        frozenLockfile: true
+      })
+    );
+    expect(yarn.install).toHaveBeenCalledTimes(1);
+    expect(yarn.install).toHaveBeenCalledWith(rootDir, 'frozen');
+  });
+
+  test('should correctly give priority to --frozen-lockfile if --pure-lockfile is also passed', async () => {
+    const rootDir = f.find('simple-project');
+    const cwd = path.join(path.join(rootDir, 'packages', 'foo'));
+    await install(
+      toInstallOptions([], {
+        cwd,
+        frozenLockfile: true,
+        pureLockfile: true
+      })
+    );
+    expect(yarn.install).toHaveBeenCalledTimes(1);
+    expect(yarn.install).toHaveBeenCalledWith(rootDir, 'frozen');
   });
 
   test('should work in project with scoped packages', async () => {

--- a/src/utils/__tests__/yarn.test.js
+++ b/src/utils/__tests__/yarn.test.js
@@ -46,16 +46,44 @@ describe('utils/yarn', () => {
       );
     });
 
+    it('should pass on lockfile flag only if requested', async () => {
+      const cwd = 'a/fake/path';
+      const localYarn = await getLocalYarnPath();
+      unsafeProcesses.spawn.mockReturnValueOnce(
+        Promise.resolve({ stdout: '' })
+      );
+      await yarn.install(cwd);
+      expect(unsafeProcesses.spawn).toHaveBeenCalledWith(
+        localYarn,
+        ['install'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
     it('should pass on pure-lockfile flag', async () => {
       const cwd = 'a/fake/path';
       const localYarn = await getLocalYarnPath();
       unsafeProcesses.spawn.mockReturnValueOnce(
         Promise.resolve({ stdout: '' })
       );
-      await yarn.install(cwd, true);
+      await yarn.install(cwd, 'pure');
       expect(unsafeProcesses.spawn).toHaveBeenCalledWith(
         localYarn,
         ['install', '--pure-lockfile'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('should pass on frozenlockfile flag', async () => {
+      const cwd = 'a/fake/path';
+      const localYarn = await getLocalYarnPath();
+      unsafeProcesses.spawn.mockReturnValueOnce(
+        Promise.resolve({ stdout: '' })
+      );
+      await yarn.install(cwd, 'frozen');
+      expect(unsafeProcesses.spawn).toHaveBeenCalledWith(
+        localYarn,
+        ['install', '--frozen-lockfile'],
         expect.objectContaining({ cwd })
       );
     });
@@ -107,7 +135,7 @@ describe('utils/yarn', () => {
       unsafeConstants.BOLT_VERSION = '9.9.9';
       const yarnUserAgent = 'yarn/7.7.7 npm/? node/v8.9.4 darwin x64';
       const boltUserAgent =
-      'bolt/9.9.9 yarn/7.7.7 npm/? node/v8.9.4 darwin x64';
+        'bolt/9.9.9 yarn/7.7.7 npm/? node/v8.9.4 darwin x64';
       const localYarn = await getLocalYarnPath();
       unsafeProcesses.spawn.mockReturnValueOnce(
         Promise.resolve({ stdout: yarnUserAgent })
@@ -123,7 +151,7 @@ describe('utils/yarn', () => {
       );
     });
   });
-  
+
   describe('add()', () => {
     let cwd;
     let project;

--- a/src/utils/yarn.js
+++ b/src/utils/yarn.js
@@ -22,11 +22,25 @@ function depTypeToFlag(depType) {
   return flag ? `--${flag}` : flag;
 }
 
-export async function install(cwd: string, pureLockfile?: boolean) {
+export type LockFileMode = 'default' | 'pure' | 'frozen';
+
+export async function install(
+  cwd: string,
+  lockfileMode: LockFileMode = 'default'
+) {
   let localYarn = path.join(await getLocalBinPath(), 'yarn');
   let installFlags = [];
 
-  if (pureLockfile) installFlags.push('--pure-lockfile');
+  switch (lockfileMode) {
+    case 'frozen':
+      installFlags.push('--frozen-lockfile');
+      break;
+    case 'pure':
+      installFlags.push('--pure-lockfile');
+      break;
+    default:
+      break;
+  }
 
   let yarnUserAgent = await userAgent();
   let boltUserAgent = `bolt/${BOLT_VERSION} ${yarnUserAgent}`;


### PR DESCRIPTION
#237

refactored internally as an enum to be a better domain language than a set of booleans. Also those options are competing so we should have only one.

No regression from before, `--pure-lockfile` still works as expected.