### PR TITLE
Fix windows compatibility Issue #207

### DIFF
--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -57,10 +57,12 @@ function stripExtension(filePath: string) {
 }
 
 async function cmdShim(src: string, dest: string) {
-  const currentShimTarget = path.resolve(
-    path.dirname(src),
-    await readCmdShim(src)
-  );
+  // If not a symlink we default to the actual src file
+  // https://github.com/npm/npm/blob/d081cc6c8d73f2aa698aab36605377c95e916224/lib/utils/gently-rm.js#L273
+  let relativeShimTarget = await readlink(src);
+  let currentShimTarget = relativeShimTarget
+    ? path.resolve(path.dirname(src), relativeShimTarget)
+    : src;
   await promisify(cb => _cmdShim(currentShimTarget, stripExtension(dest), cb));
 }
 

--- a/src/utils/symlinkPackageDependencies.js
+++ b/src/utils/symlinkPackageDependencies.js
@@ -34,7 +34,7 @@ export default async function symlinkPackageDependencies(
 
   /*********************************************************************
    * Calculate all the external dependencies that need to be symlinked *
-  **********************************************************************/
+   *********************************************************************/
 
   directoriesToCreate.push(pkg.nodeModules, pkg.nodeModulesBin);
 
@@ -87,7 +87,7 @@ export default async function symlinkPackageDependencies(
 
   /*********************************************************************
    * Calculate all the internal dependencies that need to be symlinked *
-  **********************************************************************/
+   *********************************************************************/
 
   for (let dependency of internalDeps) {
     let depWorkspace = dependencyGraph.get(dependency) || {};
@@ -101,9 +101,9 @@ export default async function symlinkPackageDependencies(
     throw new BoltError('Cannot symlink invalid set of dependencies.');
   }
 
-  /********************************************************
+  /*********************************************************
    * Calculate all the bin files that need to be symlinked *
-  *********************************************************/
+   *********************************************************/
   let projectBinFiles = await fs.readdirSafe(project.pkg.nodeModulesBin);
 
   // TODO: For now, we'll search through each of the bin files in the Project and find which ones are
@@ -118,14 +118,11 @@ export default async function symlinkPackageDependencies(
     // read the symlink to find the actual bin file (path will be relative to the symlink)
     let actualBinFileRelative = await fs.readlink(binPath);
 
-    if (!actualBinFileRelative) {
-      throw new BoltError(`${binName} is not a symlink`);
-    }
-
-    let actualBinFile = path.join(
-      project.pkg.nodeModulesBin,
-      actualBinFileRelative
-    );
+    // If not a symlink we default to the actual src file
+    // https://github.com/npm/npm/blob/d081cc6c8d73f2aa698aab36605377c95e916224/lib/utils/gently-rm.js#L273
+    let actualBinFile = actualBinFileRelative
+      ? path.join(project.pkg.nodeModulesBin, actualBinFileRelative)
+      : binPath;
 
     // To find the name of the dep that created the bin we'll get its path from node_modules and
     // use the first one or two parts (two if the package is scoped)
@@ -149,9 +146,9 @@ export default async function symlinkPackageDependencies(
     });
   }
 
-  /*****************************************************************
+  /******************************************************************
    * Calculate all the internal bin files that need to be symlinked *
-  ******************************************************************/
+   ******************************************************************/
 
   // TODO: Same as above, we should really be making sure we get all the transitive bins as well
 
@@ -192,9 +189,9 @@ export default async function symlinkPackageDependencies(
     }
   }
 
-  /**********************************
+  /***********************************
    * Create directories and symlinks *
-  ***********************************/
+   ***********************************/
 
   await yarn.runIfExists(pkg, 'preinstall');
 


### PR DESCRIPTION
Alternative fix for #207 instead of existing PR #215.

**src/utils/fs.js**

In the `readLink` method there is a comment [here](https://github.com/boltpkg/bolt/blob/master/src/utils/fs.js#L135-L136) stating code was copied from `npm` cli [here]().

The copied code doesn't have a fallback when the file is _not_ a symlink.

However when we look further in `npm` cli. The copied code is used in such a way [here](https://github.com/npm/npm/blob/d081cc6c8d73f2aa698aab36605377c95e916224/lib/utils/gently-rm.js#L273) as there _is_ a fallback similar to what @Bloodb0ne has proposed in #215.

In #215 the `try/catch` is duplicated in `cmdShim` whereas here I simply use the already safe `readLink` method.

~In this PR I also removed the unused `path-is-inside` dependency.~

**src/utils/symlinkPackageDependencies.js**

In my testing I also received`... is not a symlink` error in `symlinkPackageDependencies` for workspace packages that exposed bin scripts. In lerna these shims are not symlinks [here](https://github.com/lerna/lerna/blob/8ca18bedecf4f141c6242a099086e84b2ced72de/utils/resolve-symlink/resolve-symlink.js#L49) and considered to be packages that were erroneously installed. They are removed [here](lerna/lerna/blob/8ca18bedecf4f141c6242a099086e84b2ced72de/utils/symlink-dependencies/symlink-dependencies.js#L64) before relinking.

In `bolt` I suspect it is correct to read the shim as if it is a symlink and continue, similar to what is done in `cmdShim` (as discussed above). From what I can see `bolt` then tries to recreate the shim [here](https://github.com/boltpkg/bolt/blob/master/src/utils/fs.js#L89) which is presumably idempotent.
