### PR TITLE
fix #56 for workspaces --dev flag swallows first dependency

### DIFF
--- a/src/commands/workspace/add.js
+++ b/src/commands/workspace/add.js
@@ -30,6 +30,10 @@ export function toWorkspaceAddOptions(
   Object.keys(DEPENDENCY_TYPE_FLAGS_MAP).forEach(depTypeFlag => {
     if (flags[depTypeFlag]) {
       type = DEPENDENCY_TYPE_FLAGS_MAP[depTypeFlag];
+      // check if value of dependency flag is a package name and then push to dependency arguments
+      if (typeof flags[depTypeFlag] === 'string') {
+        depsArgs.push(options.toDependency(flags[depTypeFlag]));
+      }
     }
   });
 


### PR DESCRIPTION
This is exactly the same as #67 for the `bolt w X add -D dev-dependency` command.