### PR TITLE
chore: drop support for node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ git:
 sudo: false
 language: node_js
 node_js:
-  - '4'
   - '6'
   - '8'
   - '10'


### PR DESCRIPTION
The build is currently failing anyway, and node 4 has been unsupported for ages. This would save contributors time spend on trying to figure out why their PR is failing.