### PR TITLE
Update toDependency util to handle versions containing @ symbols

### DIFF
--- a/src/utils/__tests__/options.test.js
+++ b/src/utils/__tests__/options.test.js
@@ -48,6 +48,18 @@ describe('options', () => {
     expect(toDependency(nameWithVersion)).toEqual({ name: nameWithVersion });
     nameWithVersion = `@packageName@${version}`;
     expect(toDependency(nameWithVersion)).toEqual({ name, version });
+    // Version with @ symbol
+    expect(toDependency(`packageName@file:local/@my-packages`)).toEqual({
+      name: 'packageName',
+      version: 'file:local/@my-packages'
+    });
+    // Scoped package with @ symbol version
+    expect(
+      toDependency(`@scope/packageName@file:local/@scope/packageName`)
+    ).toEqual({
+      name: '@scope/packageName',
+      version: 'file:local/@scope/packageName'
+    });
   });
 
   test('toYarnInit', () => {

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -66,11 +66,12 @@ export function toFilterOpts(flags: Flags): FilterOpts {
  * and returns an object with the package name and version (if passed)
  */
 export function toDependency(dependencyString: string): Dependency {
-  let [name, version] = dependencyString.split('@').filter(part => part !== '');
+  let [name, ...rest] = dependencyString.split('@').filter(part => part !== '');
+  let version = rest.join('@');
   if (name.includes('/')) {
     name = '@' + name;
   }
-  return version ? { name, version } : { name };
+  return version.length > 0 ? { name, version } : { name };
 }
 
 export function toYarnInit(flags: Flags) {


### PR DESCRIPTION
E.g. local file path installs could have @ symbols, especially if the
local path contains the fully scoped package name.

Fixes #239.