### PR TITLE
Fix bolt add not reinstalling packages from the project root

### DIFF
--- a/src/commands/__tests__/add.test.js
+++ b/src/commands/__tests__/add.test.js
@@ -79,7 +79,7 @@ describe('bolt add', () => {
           cwd: projectDir
         })
       );
-      expect(yarn.add).toHaveBeenCalledTimes(0);
+      expect(yarn.add).toHaveBeenCalledTimes(1);
     });
 
     test('adding new dependency with --dev flag', async () => {


### PR DESCRIPTION
Fixes #170 

Previously running `bolt add` would not do anything if the package
already existed in the project, behaving differently from `yarn add`.
Now `bolt add` will always rerun `yarn add` when run in the project
context.
Running the command from a workspace will continue to not reinstall the
package if it already exists in the project as the package would simply
be linked from the project.