### PR TITLE
Update workspace versions when running bolt add on an existing dependency in the project root

### DIFF
--- a/src/utils/__tests__/addDependenciesToPackages.test.js
+++ b/src/utils/__tests__/addDependenciesToPackages.test.js
@@ -148,6 +148,10 @@ describe('utils/addDependenciesToPackages', () => {
     let packages = await project.getPackages();
     let fooPkg = project.getPackageByName(packages, 'foo');
     let barPkg = project.getPackageByName(packages, 'bar');
+    if (!fooPkg || !barPkg) {
+      // This check is required to satisfy flow
+      throw new Error('missing packages');
+    }
 
     expect(project.pkg.getDependencyVersionRange('global-dep')).toEqual(
       '^1.0.0'
@@ -168,6 +172,10 @@ describe('utils/addDependenciesToPackages', () => {
     packages = await project.getPackages();
     fooPkg = project.getPackageByName(packages, 'foo');
     barPkg = project.getPackageByName(packages, 'bar');
+    if (!fooPkg || !barPkg) {
+      // This check is required to satisfy flow
+      throw new Error('missing packages');
+    }
 
     expect(project.pkg.getDependencyVersionRange('global-dep')).toEqual(
       '^1.1.0'

--- a/src/utils/__tests__/addDependenciesToPackages.test.js
+++ b/src/utils/__tests__/addDependenciesToPackages.test.js
@@ -142,6 +142,44 @@ describe('utils/addDependenciesToPackages', () => {
     expect(pkg.getDependencyVersionRange('project-only-dep')).toEqual('^1.0.0');
   });
 
+  test('should update all package dependencies when run from project root', async () => {
+    let cwd = f.copy('package-with-external-deps-installed');
+    let project = await Project.init(cwd);
+    let packages = await project.getPackages();
+    let fooPkg = project.getPackageByName(packages, 'foo');
+    let barPkg = project.getPackageByName(packages, 'bar');
+
+    expect(project.pkg.getDependencyVersionRange('global-dep')).toEqual(
+      '^1.0.0'
+    );
+    expect(fooPkg.getDependencyVersionRange('global-dep')).toEqual('^1.0.0');
+    expect(barPkg.getDependencyVersionRange('global-dep')).toEqual('^1.0.0');
+
+    expect(project.pkg.getDependencyVersionRange('foo-dep')).toEqual('^1.0.0');
+    expect(fooPkg.getDependencyVersionRange('foo-dep')).toEqual('^1.0.0');
+    expect(barPkg.getDependencyVersionRange('foo-dep')).toEqual(null);
+
+    await addDependenciesToPackage(project, project.pkg, [
+      { name: 'global-dep', version: '^1.1.0' },
+      { name: 'foo-dep', version: '^1.2.0' }
+    ]);
+
+    // Refetch packages as their config will be stale
+    packages = await project.getPackages();
+    fooPkg = project.getPackageByName(packages, 'foo');
+    barPkg = project.getPackageByName(packages, 'bar');
+
+    expect(project.pkg.getDependencyVersionRange('global-dep')).toEqual(
+      '^1.1.0'
+    );
+    expect(fooPkg.getDependencyVersionRange('global-dep')).toEqual('^1.1.0');
+    expect(barPkg.getDependencyVersionRange('global-dep')).toEqual('^1.1.0');
+
+    expect(project.pkg.getDependencyVersionRange('foo-dep')).toEqual('^1.2.0');
+    expect(fooPkg.getDependencyVersionRange('foo-dep')).toEqual('^1.2.0');
+    expect(barPkg.getDependencyVersionRange('foo-dep')).toEqual(null);
+  });
+
   test('should be able to add packages with tagged versions (without specifying)', async () => {
     let cwd = f.copy('package-with-external-deps-installed');
     let project = await Project.init(cwd);

--- a/src/utils/addDependenciesToPackages.js
+++ b/src/utils/addDependenciesToPackages.js
@@ -10,6 +10,7 @@ import { BoltError } from './errors';
 import * as logger from './logger';
 import * as yarn from './yarn';
 import symlinkPackageDependencies from './symlinkPackageDependencies';
+import updateWorkspaceDependencies from '../functions/updateWorkspaceDependencies';
 
 export default async function addDependenciesToPackage(
   project: Project,
@@ -43,6 +44,15 @@ export default async function addDependenciesToPackage(
         messages.cannotInstallWorkspaceInProject(internalDeps[0].name)
       );
     }
+
+    // Update all workspace versions
+    const depsToUpgrade = externalDeps.reduce((prev, dep) => {
+      prev[dep.name] = dep.version;
+      return prev;
+    }, {});
+    await updateWorkspaceDependencies(depsToUpgrade, {
+      cwd: project.pkg.dir
+    });
     return true;
   }
 


### PR DESCRIPTION
We updated the `bolt add` command in the last version to re-run `yarn add` when run from the project root to allow installing new versions of an existing dependency without needing to run `bolt upgrade` which behaves differently (it recursively upgrades transitive deps).

As part of this work, we forgot to also update the versions of the dependency being added in each workspace in the repo. Resulting in version mismatch errors on subsequent runs of bolt until workspace versions were manually updated.