### PR TITLE
Implement help command and modify --help behaviour

### DIFF
--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -9,8 +9,6 @@ const mockedCommands: any = commands;
 describe('cli', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    // Remove listeners that the cli (and meow) attach on each run to prevent memory leaks in watch mode
-    process.removeAllListeners();
   });
   describe('--help flag', () => {
     it('should run help command if --help flag is passed with no command args', async () => {

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -1,0 +1,58 @@
+import cli from '../cli';
+import * as commands from '../commands';
+
+jest.mock('../commands');
+jest.mock('../utils/logger');
+
+const mockedCommands: any = commands;
+
+describe('cli', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    // Remove listeners that the cli (and meow) attach on each run to prevent memory leaks in watch mode
+    process.removeAllListeners();
+  });
+  describe('--help flag', () => {
+    it('should run help command if --help flag is passed with no command args', async () => {
+      const opts = {};
+      mockedCommands.toHelpOptions.mockImplementationOnce(() => opts);
+      await cli(['--help']);
+      expect(mockedCommands.toHelpOptions).toHaveBeenCalledWith([], {
+        '--': [],
+        help: true
+      });
+      expect(commands.help).toHaveBeenCalledTimes(1);
+      expect(commands.help).toHaveBeenCalledWith(opts);
+    });
+
+    it('should not run the help command if --help flag is passed WITH command args', async () => {
+      await cli(['install', '--help']);
+      expect(commands.help).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('commands', () => {
+    it('should run install command if no command args passed', async () => {
+      const opts = {};
+      mockedCommands.toInstallOptions.mockImplementationOnce(() => opts);
+      await cli([]);
+      expect(mockedCommands.toInstallOptions).toHaveBeenCalledWith([], {
+        '--': []
+      });
+      expect(commands.install).toHaveBeenCalledTimes(1);
+      expect(commands.install).toHaveBeenCalledWith(opts);
+    });
+
+    it('should run add command when "add" command is passed', async () => {
+      const opts = {};
+      mockedCommands.toAddOptions.mockImplementationOnce(() => opts);
+      await cli(['add', 'foo', '--dev']);
+      expect(mockedCommands.toAddOptions).toHaveBeenCalledWith(['foo'], {
+        '--': [],
+        dev: true
+      });
+      expect(commands.add).toHaveBeenCalledTimes(1);
+      expect(commands.add).toHaveBeenCalledWith(opts);
+    });
+  });
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -412,7 +412,7 @@ function runCommandFromCli(args: options.Args, flags: options.Flags) {
 export default async function cli(argv: Array<string>, exit: boolean = false) {
   let start = Date.now();
 
-  let { pkg, input, flags } = meow({
+  let { pkg, input, flags } = meow('', {
     argv,
     flags: {
       '--': true

--- a/src/cli.js
+++ b/src/cli.js
@@ -103,6 +103,10 @@ function runCommandFromCli(args: options.Args, flags: options.Flags) {
   let [command, ...commandArgs] = args;
   let [subCommand, ...subCommandArgs] = commandArgs;
 
+  if (typeof command === 'undefined' && flags.help) {
+    return commands.help(commands.toHelpOptions(args, flags));
+  }
+
   if (commandMap.ADD[command]) {
     return commands.add(commands.toAddOptions(commandArgs, flags));
   } else if (commandMap.AUTOCLEAN[command]) {
@@ -410,10 +414,10 @@ export default async function cli(argv: Array<string>, exit: boolean = false) {
 
   let { pkg, input, flags } = meow({
     argv,
-    help: messages.helpContent(),
     flags: {
       '--': true
-    }
+    },
+    autoHelp: false
   });
 
   logger.title(

--- a/src/commands/__tests__/help.test.js
+++ b/src/commands/__tests__/help.test.js
@@ -1,4 +1,26 @@
 // @flow
 import { help, toHelpOptions } from '../help';
+import * as messages from '../../utils/messages';
 
-test('bolt help');
+describe('bolt help', () => {
+  let consoleLogSpy;
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('should return the default help message when no subcommand is passed', async () => {
+    await help(toHelpOptions([]));
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    expect(consoleLogSpy).toHaveBeenCalledWith(messages.helpContent());
+  });
+
+  it('should throw an error when called with a subcommand', async () => {
+    await expect(help(toHelpOptions(['install']))).rejects.toBeInstanceOf(
+      Error
+    );
+    expect(consoleLogSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/commands/__tests__/help.test.js
+++ b/src/commands/__tests__/help.test.js
@@ -12,13 +12,13 @@ describe('bolt help', () => {
   });
 
   it('should return the default help message when no subcommand is passed', async () => {
-    await help(toHelpOptions([]));
+    await help(toHelpOptions([], {}));
     expect(consoleLogSpy).toHaveBeenCalledTimes(1);
     expect(consoleLogSpy).toHaveBeenCalledWith(messages.helpContent());
   });
 
   it('should throw an error when called with a subcommand', async () => {
-    await expect(help(toHelpOptions(['install']))).rejects.toBeInstanceOf(
+    await expect(help(toHelpOptions(['install'], {}))).rejects.toBeInstanceOf(
       Error
     );
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,16 +1,25 @@
 // @flow
 import * as options from '../utils/options';
 import { BoltError } from '../utils/errors';
+import * as messages from '../utils/messages';
 
-export type HelpOptions = {};
+export type HelpOptions = {
+  command?: string
+};
 
 export function toHelpOptions(
   args: options.Args,
   flags: options.Flags
 ): HelpOptions {
-  return {};
+  return {
+    command: args.length > 0 ? args[0] : undefined
+  };
 }
 
 export async function help(opts: HelpOptions) {
-  throw new BoltError('Unimplemented command "help"');
+  if (opts.command) {
+    throw new BoltError('Subcommand help information is not available yet.');
+  } else {
+    console.log(messages.helpContent());
+  }
 }


### PR DESCRIPTION
--help now only displays help information if ran with no commands, i.e.
`bolt --help`.
If a command is passed, e.g. bolt <command> --help`. the `--help` flag will be
passed through to that command and not display help text.
This fixes running npm scripts that have implemented their own flag,
e.g. `yarn run my-script-that-has-a-help-flag --help`

In the future we will implement help information for subcommands that
may handle `bolt <command> --help` as well as `bolt help <subcommand>`.