### PR TITLE
Fix --no-bail not throwing when running in default orderMode

### DIFF
--- a/src/Project.js
+++ b/src/Project.js
@@ -268,16 +268,21 @@ export default class Project {
       graph.set(pkgName, pkgInfo.dependencies);
     }
 
-    let { safe, values } = await taskGraphRunner({
-      graph,
-      force: true,
-      task: async pkgName => {
-        let pkg = this.getPackageByName(packages, pkgName);
-        if (pkg) {
-          return task(pkg);
+    let {
+      safe,
+      values
+    }: { safe: boolean, values: Map<string, T | void> } = await taskGraphRunner(
+      {
+        graph,
+        force: true,
+        task: async pkgName => {
+          let pkg = this.getPackageByName(packages, pkgName);
+          if (pkg) {
+            return task(pkg);
+          }
         }
       }
-    });
+    );
 
     if (!safe) {
       logger.warn(messages.unsafeCycles());

--- a/src/Project.js
+++ b/src/Project.js
@@ -267,21 +267,25 @@ export default class Project {
       graph.set(pkgName, pkgInfo.dependencies);
     }
 
+    let results = await taskGraphRunner({
+      graph,
+      force: true,
+      task: async pkgName => {
+        let pkg = this.getPackageByName(packages, pkgName);
+        if (pkg) {
+          return task(pkg);
+        }
+      }
+    });
+
     let {
       safe,
       values
-    }: { safe: boolean, values: Map<string, T | void> } = await taskGraphRunner(
-      {
-        graph,
-        force: true,
-        task: async pkgName => {
-          let pkg = this.getPackageByName(packages, pkgName);
-          if (pkg) {
-            return task(pkg);
-          }
-        }
-      }
-    );
+    }: { safe: boolean, values: Map<string, T | void> } = (results: {
+      safe: boolean,
+      // The value type of the Map is wrong so we cast it to any and recast to the correct type
+      values: Map<string, any>
+    });
 
     if (!safe) {
       logger.warn(messages.unsafeCycles());

--- a/src/Project.js
+++ b/src/Project.js
@@ -204,10 +204,9 @@ export default class Project {
     if (taskFailures.length > 0) {
       const failuresWithMsg = taskFailures
         .map(r => r.error && r.error.message)
-        .filter(Boolean)
-        .join('\n');
+        .filter(Boolean);
       throw new BoltError(
-        `${taskFailures.length} tasks failed.\n${failuresWithMsg}`
+        messages.taskFailed(taskFailures.length, failuresWithMsg)
       );
     }
   }

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -408,3 +408,10 @@ export function taskRunningAcrossCINodes(
 ): Message {
   return `Task is being split across ${nodes} nodes. Current node running across ${count} of ${total} workspaces`;
 }
+
+export function taskFailed(
+  numFailures: number,
+  failuresWithMsg: string[]
+): Message {
+  return `${numFailures} tasks failed.\n${failuresWithMsg.join('\n')}`;
+}

--- a/src/utils/promiseWrapper.js
+++ b/src/utils/promiseWrapper.js
@@ -1,12 +1,12 @@
 // @flow
 
-type PromiseSuccess<T> = {
+export type PromiseSuccess<T> = {
   result: T,
   status: 'success'
 };
 
-type PromiseFailure = {
-  error: mixed,
+export type PromiseFailure = {
+  error: any,
   status: 'error'
 };
 


### PR DESCRIPTION
Fixes #255.

I've also improved the error message to report the number of tasks that failed and any error messages that were in the error (which is most likely going to be none for the cli version since it spawns processes).