### PR TITLE
Add --no-prefix global flag to remove command string from spawned output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Bolt Changelog
 
-# 0.24.3
+# master
+* Add --no-prefix flag to disable prefixing subcommand output with the command string
+
+# 0.24.4
+
 * Fix --no-bail not throwing when running in default orderMode (#256)
 
 # 0.24.3
+
 * Fixes `--help` so that is is correctly passed down to other commands (#252)
 * `bolt add` on an existing dependency now correctly updates all workspaces versions if required (#251)
 * Allow exclusion of certain dependency types from dependency graph (#244)

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "inquirer": "3.3.0",
     "is-glob": "^4.0.0",
     "make-dir": "^1.0.0",
-    "meow": "^4.0.0",
+    "meow": "^5.0.0",
     "minimatch": "^3.0.4",
     "multimatch": "^2.1.0",
     "p-limit": "^1.1.0",

--- a/src/GlobalOptions.js
+++ b/src/GlobalOptions.js
@@ -1,0 +1,30 @@
+/**
+ * Singleton that manages global bolt options.
+ */
+
+import * as options from './utils/options';
+
+export type GlobalOptions = {
+  disableCmdPrefix?: boolean
+};
+class GlobalOptionsStore {
+  store = {
+    disableCmdPrefix: undefined
+  };
+  set(key: $Keys<GlobalOptions>, value: $PropertyType<GlobalOptions, key>) {
+    this.store[key] = value;
+  }
+  get(key: $Keys<GlobalOptions>): $PropertyType<GlobalOptions, key> {
+    return this.store[key];
+  }
+  getAll(): GlobalOptions {
+    return this.store;
+  }
+  setFromFlags(flags: options.Flags) {
+    if (flags.prefix === false) {
+      this.set('disableCmdPrefix', true);
+    }
+  }
+}
+
+export const globalOptions = new GlobalOptionsStore();

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -16,7 +16,6 @@ describe('cli', () => {
       mockedCommands.toHelpOptions.mockImplementationOnce(() => opts);
       await cli(['--help']);
       expect(mockedCommands.toHelpOptions).toHaveBeenCalledWith([], {
-        '--': [],
         help: true
       });
       expect(commands.help).toHaveBeenCalledTimes(1);
@@ -34,9 +33,7 @@ describe('cli', () => {
       const opts = {};
       mockedCommands.toInstallOptions.mockImplementationOnce(() => opts);
       await cli([]);
-      expect(mockedCommands.toInstallOptions).toHaveBeenCalledWith([], {
-        '--': []
-      });
+      expect(mockedCommands.toInstallOptions).toHaveBeenCalledWith([], {});
       expect(commands.install).toHaveBeenCalledTimes(1);
       expect(commands.install).toHaveBeenCalledWith(opts);
     });
@@ -46,7 +43,6 @@ describe('cli', () => {
       mockedCommands.toAddOptions.mockImplementationOnce(() => opts);
       await cli(['add', 'foo', '--dev']);
       expect(mockedCommands.toAddOptions).toHaveBeenCalledWith(['foo'], {
-        '--': [],
         dev: true
       });
       expect(commands.add).toHaveBeenCalledTimes(1);

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -1,8 +1,14 @@
 import cli from '../cli';
 import * as commands from '../commands';
+import { globalOptions } from '../GlobalOptions';
 
 jest.mock('../commands');
 jest.mock('../utils/logger');
+jest.mock('../GlobalOptions', () => ({
+  globalOptions: {
+    setFromFlags: jest.fn()
+  }
+}));
 
 const mockedCommands: any = commands;
 
@@ -47,6 +53,130 @@ describe('cli', () => {
       });
       expect(commands.add).toHaveBeenCalledTimes(1);
       expect(commands.add).toHaveBeenCalledWith(opts);
+    });
+  });
+  describe('global flags', () => {
+    it('should parse global flags before a command', async () => {
+      const opts = {};
+      mockedCommands.toAddOptions.mockImplementationOnce(() => opts);
+      await cli(['--no-prefix', 'add', 'foo']);
+      expect(mockedCommands.toAddOptions).toHaveBeenCalledWith(['foo'], {
+        prefix: false
+      });
+      expect(commands.add).toHaveBeenCalledTimes(1);
+      expect(commands.add).toHaveBeenCalledWith(opts);
+    });
+    it('should parse global flags after a command', async () => {
+      const opts = {};
+      mockedCommands.toAddOptions.mockImplementationOnce(() => opts);
+      await cli(['add', 'foo', '--no-prefix']);
+      expect(mockedCommands.toAddOptions).toHaveBeenCalledWith(['foo'], {
+        prefix: false
+      });
+      expect(commands.add).toHaveBeenCalledTimes(1);
+      expect(commands.add).toHaveBeenCalledWith(opts);
+    });
+    it('should set global flags in globalOptions store', async () => {
+      expect(globalOptions.setFromFlags).not.toHaveBeenCalled();
+      await cli(['add', 'foo', '--no-prefix']);
+      expect(globalOptions.setFromFlags).toHaveBeenCalledTimes(1);
+      expect(globalOptions.setFromFlags).toHaveBeenCalledWith({
+        prefix: false
+      });
+    });
+  });
+  describe('passing flags to run commands', () => {
+    it('bolt script --flag1 --flag2', async () => {
+      const opts = {};
+      mockedCommands.toRunOptions.mockImplementationOnce(() => opts);
+      await cli(['script', '--flag1', '--flag2']);
+      expect(mockedCommands.toRunOptions).toHaveBeenCalledWith(['script'], {
+        flag1: true,
+        flag2: true
+      });
+      expect(commands.run).toHaveBeenCalledTimes(1);
+      expect(commands.run).toHaveBeenCalledWith(opts);
+    });
+    it('bolt run script --flag1 --flag2', async () => {
+      const opts = {};
+      mockedCommands.toRunOptions.mockImplementationOnce(() => opts);
+      await cli(['run', 'script', '--flag1', '--flag2']);
+      expect(mockedCommands.toRunOptions).toHaveBeenCalledWith(['script'], {
+        flag1: true,
+        flag2: true
+      });
+      expect(commands.run).toHaveBeenCalledTimes(1);
+      expect(commands.run).toHaveBeenCalledWith(opts);
+    });
+    it('bolt p run script --flag1 --flag2', async () => {
+      const opts = {};
+      mockedCommands.toProjectRunOptions.mockImplementationOnce(() => opts);
+      await cli(['p', 'run', 'script', '--flag1', '--flag2']);
+      expect(mockedCommands.toProjectRunOptions).toHaveBeenCalledWith(
+        ['script'],
+        {
+          flag1: true,
+          flag2: true
+        }
+      );
+      expect(commands.projectRun).toHaveBeenCalledTimes(1);
+      expect(commands.projectRun).toHaveBeenCalledWith(opts);
+    });
+    it('bolt w my-package run script --flag1 --flag2', async () => {
+      const opts = {};
+      mockedCommands.toWorkspaceRunOptions.mockImplementationOnce(() => opts);
+      await cli(['w', 'my-package', 'run', 'script', '--flag1', '--flag2']);
+      expect(mockedCommands.toWorkspaceRunOptions).toHaveBeenCalledWith(
+        ['my-package', 'script'],
+        {
+          flag1: true,
+          flag2: true
+        }
+      );
+      expect(commands.workspaceRun).toHaveBeenCalledTimes(1);
+      expect(commands.workspaceRun).toHaveBeenCalledWith(opts);
+    });
+    it('bolt ws --only="my-package" run script -- --flag1 --flag2', async () => {
+      const opts = {};
+      mockedCommands.toWorkspacesRunOptions.mockImplementationOnce(() => opts);
+      await cli([
+        'ws',
+        '--only=my-package',
+        'run',
+        'script',
+        '--',
+        '--flag1',
+        '--flag2'
+      ]);
+      expect(mockedCommands.toWorkspacesRunOptions).toHaveBeenCalledWith(
+        ['script'],
+        {
+          '--': ['--flag1', '--flag2'],
+          only: 'my-package'
+        }
+      );
+      expect(commands.workspacesRun).toHaveBeenCalledTimes(1);
+      expect(commands.workspacesRun).toHaveBeenCalledWith(opts);
+    });
+    it('bolt ws exec --only="my-package" -- yarn script  --flag1 --flag2', async () => {
+      const opts = {};
+      mockedCommands.toWorkspacesExecOptions.mockImplementationOnce(() => opts);
+      await cli([
+        'ws',
+        'exec',
+        '--only=my-package',
+        '--',
+        'yarn',
+        'script',
+        '--flag1',
+        '--flag2'
+      ]);
+      expect(mockedCommands.toWorkspacesExecOptions).toHaveBeenCalledWith([], {
+        '--': ['yarn', 'script', '--flag1', '--flag2'],
+        only: 'my-package'
+      });
+      expect(commands.workspacesExec).toHaveBeenCalledTimes(1);
+      expect(commands.workspacesExec).toHaveBeenCalledWith(opts);
     });
   });
 });

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,6 +8,7 @@ import { BoltError } from './utils/errors';
 import cleanStack from 'clean-stack';
 import * as commands from './commands';
 import * as options from './utils/options';
+import { globalOptions } from './GlobalOptions';
 
 const commandMap = {
   ADD: { add: true },
@@ -415,9 +416,15 @@ export default async function cli(argv: Array<string>, exit: boolean = false) {
   let { pkg, input, flags } = meow('', {
     argv,
     flags: {
-      '--': true
+      '--': true,
+      /* Global options as defined in GlobalOptions.js.
+       * Added here so bolt --<option> <cmd> doesn't parse <cmd> as the value of the <option> flag */
+      prefix: {
+        type: 'boolean'
+      }
     },
-    autoHelp: false
+    autoHelp: false,
+    booleanDefault: undefined
   });
 
   logger.title(
@@ -429,6 +436,7 @@ export default async function cli(argv: Array<string>, exit: boolean = false) {
   processes.handleSignals();
 
   try {
+    globalOptions.setFromFlags(flags);
     await runCommandFromCli(input, flags);
   } catch (err) {
     if (err instanceof BoltError) {

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -28,8 +28,12 @@ function fmt(str: Message | Buffer | string, opts: LoggerOpts = {}) {
   return result;
 }
 
-function prompt(pkg) {
-  return (pkg ? '(' + pkg.config.getName() + ') ' : '') + '$ ';
+function prompt(pkg, cmd) {
+  let prompt = pkg ? '(' + pkg.config.getName() + ')' : '';
+  if (!cmd) {
+    return prompt;
+  }
+  return prompt + ' $ ' + cmd;
 }
 
 function write(
@@ -81,7 +85,7 @@ export function stdout(
   pkg?: Package,
   opts: LoggerOpts = {}
 ) {
-  let prefix = chalk.cyan(prompt(pkg) + cmd);
+  let prefix = chalk.cyan(prompt(pkg, cmd));
   write(data, { prefix, ...opts }, false);
 }
 
@@ -91,12 +95,12 @@ export function stderr(
   pkg?: Package,
   opts: LoggerOpts = {}
 ) {
-  let prefix = chalk.red(prompt(pkg) + cmd);
+  let prefix = chalk.red(prompt(pkg, cmd));
   write(data, { prefix, ...opts }, true);
 }
 
 export function cmd(cmd: string, args: Array<string>, opts: LoggerOpts = {}) {
-  let msg = chalk.dim(prompt() + cmd);
+  let msg = chalk.dim(prompt(null, cmd));
   if (args.length) {
     msg += ' ';
     msg += chalk.magenta(args.join(' '));

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -190,6 +190,9 @@ export function helpContent(): string {
     usage
       $ bolt [command] <...args> <...opts>
 
+    options:
+      --no-prefix Do not prefix spawned process output with the command string
+
     commands
       init         init a bolt project
       install      install a bolt project

--- a/src/utils/processes.js
+++ b/src/utils/processes.js
@@ -7,6 +7,7 @@ import type Project from '../Project';
 import pLimit from 'p-limit';
 import os from 'os';
 import path from 'path';
+import { globalOptions, type GlobalOptions } from '../GlobalOptions';
 
 const limit = pLimit(os.cpus().length);
 const processes = new Set();
@@ -37,6 +38,7 @@ export class ChildProcessError extends Error {
 }
 
 export type SpawnOptions = {
+  ...GlobalOptions,
   cwd?: string,
   pkg?: Package,
   silent?: boolean,
@@ -58,7 +60,11 @@ export function spawn(
         let isTTY = process.stdout.isTTY && opts.tty;
         let cmdDisplayName = opts.useBasename ? path.basename(cmd) : cmd;
 
-        let cmdStr = cmdDisplayName + ' ' + args.join(' ');
+        let displayCmd =
+          opts.disableCmdPrefix != null
+            ? opts.disableCmdPrefix
+            : globalOptions.get('disableCmdPrefix');
+        let cmdStr = displayCmd ? '' : cmdDisplayName + ' ' + args.join(' ');
 
         let spawnOpts: child_process$spawnOpts = {
           cwd: opts.cwd,

--- a/src/utils/yarn.js
+++ b/src/utils/yarn.js
@@ -100,7 +100,8 @@ export async function add(
   await spawnWithUserAgent(localYarn, spawnArgs, {
     cwd: pkg.dir,
     pkg: pkg,
-    tty: true
+    tty: true,
+    useBasename: true
   });
 }
 
@@ -125,7 +126,8 @@ export async function upgrade(
   await spawnWithUserAgent(localYarn, [...spawnArgs, ...flags], {
     cwd: pkg.dir,
     pkg: pkg,
-    tty: true
+    tty: true,
+    useBasename: true
   });
 }
 
@@ -218,7 +220,8 @@ export async function userAgent() {
     localYarn,
     ['config', 'get', 'user-agent'],
     {
-      tty: false
+      tty: false,
+      silent: true
     }
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2950,20 +2950,20 @@ map-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
   integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
 
-meow@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.0.tgz#fd5855dd008db5b92c552082db1c307cba20b29d"
-  integrity sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==
+meow@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
+  integrity sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
   dependencies:
     camelcase-keys "^4.0.0"
     decamelize-keys "^1.0.0"
     loud-rejection "^1.0.0"
-    minimist "^1.1.3"
     minimist-options "^3.0.1"
     normalize-package-data "^2.3.4"
     read-pkg-up "^3.0.0"
     redent "^2.0.0"
     trim-newlines "^2.0.0"
+    yargs-parser "^10.0.0"
 
 merge@^1.1.3:
   version "1.2.0"
@@ -3026,7 +3026,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
@@ -4445,6 +4445,13 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
I've created a `globalOptions` singleton to store global flags to prevent passing args down everywhere.

I considered adding `useBasename` as an option as well but didn't think it would be useful enough for the end consumer to add as a flag. We only use it when executing yarn commands.

I also made some other yarn commands print basename and silenced the output of the user agent call we make.