### PR TITLE
fix issue where bolt twice would break during bin symlink step

### DIFF
--- a/src/commands/__tests__/install.test.js
+++ b/src/commands/__tests__/install.test.js
@@ -197,4 +197,28 @@ describe('install', () => {
 
     expect(stat.isFile()).toBe(true);
   });
+
+  test('workspaces with bins installing twice still works', async () => {
+    let cwd = f.copy('workspace-with-bin');
+    let project = await Project.init(cwd);
+
+    await install(toInstallOptions([], { cwd }));
+
+    let binPath = path.join(
+      cwd,
+      'packages',
+      'foo',
+      'node_modules',
+      '.bin',
+      'bar'
+    );
+    let stat = await fs.stat(binPath);
+
+    expect(stat.isFile()).toBe(true);
+    
+    // Test to make sure existing symlink problem doesn't break. It used to die if you ran bolt twice
+    await install(toInstallOptions([], { cwd }));
+
+    expect(stat.isFile()).toBe(true);
+  });
 });

--- a/src/utils/symlinkPackageDependencies.js
+++ b/src/utils/symlinkPackageDependencies.js
@@ -173,8 +173,8 @@ export default async function symlinkPackageDependencies(
       let binName = dependency.split('/').pop();
       let src = path.join(depWorkspace.pkg.dir, depBinFiles);
       let dest = path.join(pkg.nodeModulesBin, binName);
-
-      symlinksToCreate.push({ src, dest, type: 'exec' });
+      let exists = await fs.symlinkExists(dest);
+      !exists && symlinksToCreate.push({ src, dest, type: 'exec' });
       continue;
     }
 
@@ -184,7 +184,8 @@ export default async function symlinkPackageDependencies(
 
       // Just in case the symlink is already added (it might have already existed in the projects bin/)
       if (!symlinksToCreate.find(symlink => symlink.dest === dest)) {
-        symlinksToCreate.push({ src, dest, type: 'exec' });
+        let exists = await fs.symlinkExists(dest);
+        !exists && symlinksToCreate.push({ src, dest, type: 'exec' });
       }
     }
   }


### PR DESCRIPTION
Easy to replicate problem. Running bolt once was fine, when using a locally symlinked bin. However, running it again would throw an error. This should fix.

I think this addresses #226.