### PR TITLE
updates for faster symlinking

### DIFF
--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -61,10 +61,15 @@ export async function install(opts: InstallOptions) {
     prefix: false
   });
 
-  for (let pkg of packages) {
-    let dependencies = Array.from(pkg.getAllDependencies().keys());
-    await symlinkPackageDependencies(project, pkg, dependencies);
+  let { graph, valid } = await project.getDependencyGraph(packages);
+  if (!valid) {
+    throw new BoltError('Cannot symlink invalid set of dependencies.');
   }
+
+  await Promise.all(packages.map(async (pkg) => {
+    let dependencies = Array.from(pkg.getAllDependencies().keys());
+    await symlinkPackageDependencies(project, pkg, dependencies, packages, graph);
+  }));
 
   logger.info(messages.linkingWorkspaceBinaries(), {
     emoji: '🚀',

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -68,7 +68,7 @@ export async function install(opts: InstallOptions) {
 
   await Promise.all(packages.map(async (pkg) => {
     let dependencies = Array.from(pkg.getAllDependencies().keys());
-    await symlinkPackageDependencies(project, pkg, dependencies, packages, graph);
+    await symlinkPackageDependencies(project, pkg, dependencies, graph);
   }));
 
   logger.info(messages.linkingWorkspaceBinaries(), {

--- a/src/utils/__tests__/addDependenciesToPackages.test.js
+++ b/src/utils/__tests__/addDependenciesToPackages.test.js
@@ -132,8 +132,10 @@ describe('utils/addDependenciesToPackages', () => {
     await addDependenciesToPackage(project, pkg, [
       { name: 'project-only-dep' }
     ]);
+    let packagesFinal = await project.getPackages();
+    let { graph } = await project.getDependencyGraph(packagesFinal);
 
-    expect(symlinkSpy).toHaveBeenCalledWith(project, pkg, ['project-only-dep']);
+    expect(symlinkSpy).toHaveBeenCalledWith(project, pkg, ['project-only-dep'], graph);
   });
 
   test('should update packages dependencies in package config', async () => {
@@ -147,8 +149,10 @@ describe('utils/addDependenciesToPackages', () => {
     await addDependenciesToPackage(project, pkg, [
       { name: 'project-only-dep' }
     ]);
+    let packagesFinal = await project.getPackages();
+    let { graph } = await project.getDependencyGraph(packagesFinal);
 
-    expect(symlinkSpy).toHaveBeenCalledWith(project, pkg, ['project-only-dep']);
+    expect(symlinkSpy).toHaveBeenCalledWith(project, pkg, ['project-only-dep'], graph);
     expect(pkg.getDependencyVersionRange('project-only-dep')).toEqual('^1.0.0');
   });
 
@@ -226,8 +230,10 @@ describe('utils/addDependenciesToPackages', () => {
 
       expect(pkg.getDependencyVersionRange('baz')).toEqual(null);
       await addDependenciesToPackage(project, pkg, [{ name: 'baz' }]);
+      let packagesFinal = await project.getPackages();
+      let { graph } = await project.getDependencyGraph(packagesFinal);
 
-      expect(symlinkSpy).toHaveBeenCalledWith(project, pkg, ['baz']);
+      expect(symlinkSpy).toHaveBeenCalledWith(project, pkg, ['baz'], graph);
       expect(pkg.getDependencyVersionRange('baz')).toEqual('^1.0.1');
     });
 
@@ -237,14 +243,17 @@ describe('utils/addDependenciesToPackages', () => {
       let project = await Project.init(cwd);
       let packages = await project.getPackages();
       let pkg = project.getPackageByName(packages, 'bar');
+
       if (!pkg) throw new Error('missing bar');
 
       expect(pkg.getDependencyVersionRange('baz')).toEqual(null);
       await addDependenciesToPackage(project, pkg, [
         { name: 'baz', version: '^1.0.0' }
       ]);
+      let packagesFinal = await project.getPackages();
+      let { graph } = await project.getDependencyGraph(packagesFinal);
 
-      expect(symlinkSpy).toHaveBeenCalledWith(project, pkg, ['baz']);
+      expect(symlinkSpy).toHaveBeenCalledWith(project, pkg, ['baz'], graph);
       expect(pkg.getDependencyVersionRange('baz')).toEqual('^1.0.0');
     });
 

--- a/src/utils/__tests__/symlinkPackageDependencies.test.js
+++ b/src/utils/__tests__/symlinkPackageDependencies.test.js
@@ -29,37 +29,45 @@ const FIXTURE_NAME = 'nested-workspaces-with-root-dependencies-installed';
 describe('utils/symlinkPackageDependencies()', () => {
   test('creates node_modules and node_modules/.bin', async () => {
     let project = await initProject(FIXTURE_NAME);
+    let packages = await project.getPackages();
+    let { graph } = await project.getDependencyGraph(packages);
     let pkg = await getPackage(project, 'foo');
     expect(await fs.dirExists(pkg.nodeModules)).toBe(false);
     expect(await fs.dirExists(pkg.nodeModulesBin)).toBe(false);
-    await symlinkPackageDependencies(project, pkg, ['bar']);
+    await symlinkPackageDependencies(project, pkg, ['bar'], graph);
     expect(await fs.dirExists(pkg.nodeModules)).toBe(true);
     expect(await fs.dirExists(pkg.nodeModulesBin)).toBe(true);
   });
 
   test('symlinks external dependencies', async () => {
     let project = await initProject(FIXTURE_NAME);
+    let packages = await project.getPackages();
+    let { graph } = await project.getDependencyGraph(packages);
     let pkg = await getPackage(project, 'foo');
     let depPath = path.join(pkg.nodeModules, 'external-dep');
     expect(await fs.dirExists(depPath)).toBe(false);
-    await symlinkPackageDependencies(project, pkg, ['external-dep']);
+    await symlinkPackageDependencies(project, pkg, ['external-dep'], graph);
     expect(await fs.dirExists(depPath)).toBe(true);
   });
 
   test('symlinks internal dependencies', async () => {
     let project = await initProject(FIXTURE_NAME);
+    let packages = await project.getPackages();
+    let { graph } = await project.getDependencyGraph(packages);
     let pkg = await getPackage(project, 'foo');
     let depPath = path.join(pkg.nodeModules, 'bar');
     expect(await fs.dirExists(depPath)).toEqual(false);
-    await symlinkPackageDependencies(project, pkg, ['bar']);
+    await symlinkPackageDependencies(project, pkg, ['bar'], graph);
     expect(await fs.dirExists(depPath)).toEqual(true);
     expect(await fs.symlinkExists(depPath)).toEqual(true);
   });
 
   test('runs correct lifecycle scripts', async () => {
     let project = await initProject(FIXTURE_NAME);
+    let packages = await project.getPackages();
+    let { graph } = await project.getDependencyGraph(packages);
     let pkg = await getPackage(project, 'foo');
-    await symlinkPackageDependencies(project, pkg, ['bar']);
+    await symlinkPackageDependencies(project, pkg, ['bar'], graph);
     expect(yarn.runIfExists).toHaveBeenCalledTimes(4);
     expect(unsafeYarn.runIfExists.mock.calls[0][1]).toEqual('preinstall');
     expect(unsafeYarn.runIfExists.mock.calls[1][1]).toEqual('postinstall');
@@ -69,41 +77,49 @@ describe('utils/symlinkPackageDependencies()', () => {
 
   test('symlinks external deps bins (string)', async () => {
     let project = await initProject(FIXTURE_NAME);
+    let packages = await project.getPackages();
+    let { graph } = await project.getDependencyGraph(packages);
     let pkg = await getPackage(project, 'zee');
     let symPath = path.join(pkg.nodeModulesBin, 'external-dep-with-bin');
     expect(await fs.symlinkExists(symPath)).toEqual(false);
-    await symlinkPackageDependencies(project, pkg, ['external-dep-with-bin']);
+    await symlinkPackageDependencies(project, pkg, ['external-dep-with-bin'], graph);
     expect(await fs.symlinkExists(symPath)).toEqual(true);
   });
 
   test('symlinks external deps bins (object)', async () => {
     let project = await initProject(FIXTURE_NAME);
+    let packages = await project.getPackages();
+    let { graph } = await project.getDependencyGraph(packages);
     let pkg = await getPackage(project, 'zee');
     let symPath = path.join(pkg.nodeModulesBin, 'external-dep-two-bins-1');
     expect(await fs.symlinkExists(symPath)).toEqual(false);
     await symlinkPackageDependencies(project, pkg, [
       'external-dep-with-two-bins'
-    ]);
+    ], graph);
     expect(await fs.symlinkExists(symPath)).toEqual(true);
   });
 
   test('symlinks internal deps bins (string)', async () => {
     let project = await initProject(FIXTURE_NAME);
+    let packages = await project.getPackages();
+    let { graph } = await project.getDependencyGraph(packages);
     let pkg = await getPackage(project, 'zee');
     let symPath = path.join(pkg.nodeModulesBin, 'bar');
     expect(await fs.symlinkExists(symPath)).toEqual(false);
-    await symlinkPackageDependencies(project, pkg, ['bar']);
+    await symlinkPackageDependencies(project, pkg, ['bar'], graph);
     expect(await fs.symlinkExists(symPath)).toEqual(true);
   });
 
   test('symlinks internal deps bins (when declared using object)', async () => {
     let project = await initProject(FIXTURE_NAME);
+    let packages = await project.getPackages();
+    let { graph } = await project.getDependencyGraph(packages);
     let pkg = await getPackage(project, 'zee');
     let baz1Path = path.join(pkg.nodeModulesBin, 'baz-1');
     let baz2Path = path.join(pkg.nodeModulesBin, 'baz-2');
     expect(await fs.symlinkExists(baz1Path)).toEqual(false);
     expect(await fs.symlinkExists(baz2Path)).toEqual(false);
-    await symlinkPackageDependencies(project, pkg, ['baz']);
+    await symlinkPackageDependencies(project, pkg, ['baz'], graph);
     expect(await fs.symlinkExists(baz1Path)).toEqual(true);
     expect(await fs.symlinkExists(baz2Path)).toEqual(true);
   });

--- a/src/utils/addDependenciesToPackages.js
+++ b/src/utils/addDependenciesToPackages.js
@@ -97,5 +97,9 @@ export default async function addDependenciesToPackage(
     await pkg.setDependencyVersionRange(depName, type, String(depVersion));
   }
 
-  await symlinkPackageDependencies(project, pkg, dependencyNames);
+  // Now that all the new stuff is there, do this one more time to get the updates
+  let packagesFinal = await project.getPackages();
+  let { graph: depGraphFinal } = await project.getDependencyGraph(packagesFinal);
+
+  await symlinkPackageDependencies(project, pkg, dependencyNames, depGraphFinal);
 }

--- a/src/utils/symlinkPackageDependencies.js
+++ b/src/utils/symlinkPackageDependencies.js
@@ -15,23 +15,8 @@ export default async function symlinkPackageDependencies(
   project: Project,
   pkg: Package,
   dependencies: Array<string>,
-  pkgs: Array<Packages>,
   dependencyGraph,
 ) {
-
-  let packages = pkgs || await project.getPackages();
-  
-  let valid;
-  let dependencyGraphValid = true;
-
-  if (!dependencyGraph) {
-    let {
-      graph,
-      valid,
-    } = await project.getDependencyGraph(packages);
-    dependencyGraph = graph;
-    dependencyGraphValid = valid;
-  }
   
   let pkgName = pkg.config.getName();
   // get all the dependencies that are internal workspaces in this project
@@ -40,7 +25,7 @@ export default async function symlinkPackageDependencies(
   let directoriesToCreate = [];
   let symlinksToCreate = [];
 
-  valid = true;
+  let valid = true;
 
   /*********************************************************************
    * Calculate all the external dependencies that need to be symlinked *
@@ -109,7 +94,7 @@ export default async function symlinkPackageDependencies(
     symlinksToCreate.push({ src, dest, type: 'junction' });
   }
 
-  if (!dependencyGraphValid || !valid) {
+  if (!valid) {
     throw new BoltError('Cannot symlink invalid set of dependencies.');
   }
 
@@ -217,7 +202,7 @@ export default async function symlinkPackageDependencies(
   await Promise.all(
     symlinksToCreate.map(async ({ src, dest, type }) => {
       const symlinkExists = await fs.symlinkExists(dest);
-      
+
       if (!symlinkExists) {
         await fs.symlink(src, dest, type);
       }


### PR DESCRIPTION
Rather than re-fetch the Project packages, and graph during the for of loop from the install command, simply passing them in saves a ton of time.

Converts the for of loop for symlinking into a Promise.all.

Don't re-create symlinks.

In our project we have ~360 internal packages, and ~370 external.

Before...
![](https://d.pr/i/SUfGVY+)

After..
![](https://d.pr/i/G7SqGe+)

