### PR TITLE
Indepdent upgrade spike

### DIFF
--- a/src/Project.js
+++ b/src/Project.js
@@ -106,6 +106,7 @@ export default class Project {
 
     for (let pkg of queue) {
       let name = pkg.config.getName();
+      let legacyName = `${name}-legacy`;
       let dependencies = [];
       let allDependencies = pkg.getAllDependencies(excludedDependencyTypes);
 
@@ -116,6 +117,13 @@ export default class Project {
         let actual = depVersion;
         let expected = match.config.getVersion();
 
+        if (
+          match.config.getName() === '@atlaskit/editor-core' &&
+          name === 'react-intl'
+        ) {
+          debugger;
+          console.log(expected);
+        }
         // Workspace dependencies only need to semver satisfy, not '==='
         if (!semver.satisfies(expected, depVersion)) {
           valid = false;

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -62,6 +62,7 @@ export function depMustMatchProject(
   expected: string,
   actual: string
 ): Message {
+  debugger;
   return `Package ${normalPkg(pkgName)} dependency ${normalPkg(
     depName
   )} must match version in project dependencies. ${goodVer(


### PR DESCRIPTION
Obviously spike code, but this work in atlassian-frontend:
<img width="1006" alt="Screen Shot 2021-06-17 at 5 58 16 pm" src="https://user-images.githubusercontent.com/1107647/122356172-e2f95580-cf95-11eb-94be-c2cbe7224437.png">
<img width="756" alt="Screen Shot 2021-06-17 at 6 00 54 pm" src="https://user-images.githubusercontent.com/1107647/122356268-f86e7f80-cf95-11eb-9c31-976d60bca1f6.png">

For my spike I only switched editor-core to the old version of intl