### PR TITLE
Always symlink internal dependencies even if they already exist

### DIFF
--- a/src/utils/symlinkPackageDependencies.js
+++ b/src/utils/symlinkPackageDependencies.js
@@ -88,7 +88,7 @@ export default async function symlinkPackageDependencies(
     let src = depWorkspace.pkg.dir;
     let dest = path.join(pkg.nodeModules, dependency);
 
-    symlinksToCreate.push({ src, dest, type: 'junction' });
+    symlinksToCreate.push({ src, dest, type: 'junction', recreate: true });
   }
 
   if (!valid) {
@@ -197,10 +197,10 @@ export default async function symlinkPackageDependencies(
   );
 
   await Promise.all(
-    symlinksToCreate.map(async ({ src, dest, type }) => {
+    symlinksToCreate.map(async ({ src, dest, type, recreate }) => {
       const symlinkExists = await fs.symlinkExists(dest);
 
-      if (!symlinkExists) {
+      if (!symlinkExists || recreate) {
         await fs.symlink(src, dest, type);
       }
     })


### PR DESCRIPTION
Internal dependency symlinks can become stale if the dependency changes
paths in the repo so its best to always recreate them for robustness.
The performance cost of this change isn't too bad as the majority of the symlinking
slowdown is caused by the .bin symlinking.

---

Locally in atlassian-frontend this takes about 5 seconds longer but the variance between installs can be more than 5 seconds so its hard to measure the performance impact. On CI the performance was the same.

Removing the existing symlink check blows out local installs from ~30s to ~90s which verifies that the bin symlinks are the slowdowns (which makes sense as its symlinking all the bins of the entire project for each package in the repo regardless of its declared dependencies).